### PR TITLE
Sdmcms cleanup

### DIFF
--- a/apps/SdmContentGenerator/SdmContentGenerator.php
+++ b/apps/SdmContentGenerator/SdmContentGenerator.php
@@ -98,4 +98,4 @@ if ($sdmassembler->sdmCoreDetermineRequestedPage() === 'SdmContentGenerator') {
     }
     $output .= '</ul>';
 }
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, $output, $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, $options);

--- a/apps/SdmDevMenu/SdmDevMenu.php
+++ b/apps/SdmDevMenu/SdmDevMenu.php
@@ -1,7 +1,7 @@
 <?php
 
 // app description page | if you visit YOURSITE.com/index.php?page=SdmDevMenu this output will be dsiplayed
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<h2>DEV MENU</h2><p>The SDM DEV MENU app outputs a menu that has links to all pages available in core, and any page that matches the name of an enabled app. For now the meni itself is restricted to the user role "root", and the SdmDevMenu app page is not restricted at all. This is for testing the new role checking being done before loading our apps.</p>', array('wrapper' => 'main_content', 'incmethod' => 'overwrite', 'incpages' => array('SdmDevMenu')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h2>DEV MENU</h2><p>The SDM DEV MENU app outputs a menu that has links to all pages available in core, and any page that matches the name of an enabled app. For now the meni itself is restricted to the user role "root", and the SdmDevMenu app page is not restricted at all. This is for testing the new role checking being done before loading our apps.</p>', array('wrapper' => 'main_content', 'incmethod' => 'overwrite', 'incpages' => array('SdmDevMenu')));
 // add a dev menu to all pages that includes links to all pages and enabled apps
 $pages = $sdmassembler->sdmCoreDetermineAvailablePages();
 // Possibly incorporate the following few lines that put together a list of available apps and pages into one array into the sdmCoreDetermineAvailablePages() method
@@ -13,4 +13,4 @@ foreach ($availablePages as $link) {
 }
 $devMenu .= '</ul></div><!-- End Dev Menu -->';
 // incorporate devmenu
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, $devMenu, array('wrapper' => 'side-menu', 'incmethod' => 'append', 'incpages' => $availablePages, 'roles' => array('root')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $devMenu, array('wrapper' => 'side-menu', 'incmethod' => 'append', 'incpages' => $availablePages, 'roles' => array('root')));

--- a/apps/SdmDevOutput/SdmDevOutput.php
+++ b/apps/SdmDevOutput/SdmDevOutput.php
@@ -1,4 +1,4 @@
 <?php
 
 $output = '<!-- Sdm Dev Output App Placeholder -->';
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, $output);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output);

--- a/apps/gitTools/gitTools.php
+++ b/apps/gitTools/gitTools.php
@@ -18,4 +18,3 @@ $output = "<div style='clear:both;color: #66CCCC; background: #000000; border-ra
 $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, array('incmethod' => 'prepend'));
 
 $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>Git Tools</h3><p>This app provides tools for working with git. At the moment the only tool is a <i>branch viewer</i> that show the current git branch at the top of the main_content menu wrapper on every page.</p><p>Further development of this app will occur in the future, and this app will have a variety of tools for using git with your SDM CMS site.</p>', array('incpages' => array('gitTools'), 'incmethod' => 'append'));
-?>

--- a/apps/gitTools/gitTools.php
+++ b/apps/gitTools/gitTools.php
@@ -15,7 +15,7 @@ $branchname = $explodedstring[2]; //get the one that is always the branch name
 
 $output = "<div style='clear:both;color: #66CCCC; background: #000000; border-radius: 9px; padding: 10px; margin: 0px 0px 20px 0px; text-align: center;'>Current GIT branch: <i style='color: #00CC33; text-transform: uppercase;'>" . $branchname . "</i></div>";
 
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, $output, array('incmethod' => 'prepend'));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, array('incmethod' => 'prepend'));
 
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<h3>Git Tools</h3><p>This app provides tools for working with git. At the moment the only tool is a <i>branch viewer</i> that show the current git branch at the top of the main_content menu wrapper on every page.</p><p>Further development of this app will occur in the future, and this app will have a variety of tools for using git with your SDM CMS site.</p>', array('incpages' => array('gitTools'), 'incmethod' => 'append'));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>Git Tools</h3><p>This app provides tools for working with git. At the moment the only tool is a <i>branch viewer</i> that show the current git branch at the top of the main_content menu wrapper on every page.</p><p>Further development of this app will occur in the future, and this app will have a variety of tools for using git with your SDM CMS site.</p>', array('incpages' => array('gitTools'), 'incmethod' => 'append'));
 ?>

--- a/apps/helloWorld/helloWorld.php
+++ b/apps/helloWorld/helloWorld.php
@@ -13,4 +13,4 @@ $options = array(
 ); // options array determines how an apps output is incorporated into the page
 $devmode = false; // if set to true then dev data about the app output will be displayed on the page as well
 // we use the Sdm Assembler's sdmAssemblerIncorporateAppOutput() method to display our apps output on the page
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, $output, $options, $devmode);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, $options, $devmode);

--- a/apps/jqueryPlay/js/jqueryPlay.js
+++ b/apps/jqueryPlay/js/jqueryPlay.js
@@ -1,9 +1,9 @@
 var alerted = localStorage.getItem('alerted') || '';
-if (alerted != 'yes') {
+if (alerted !== 'yes') {
 // first check if jQuery has been loaded
-    if (typeof jQuery != 'undefined') {
+    if (typeof jQuery !== 'undefined') {
         // then check if jQuery UI has been loaded
-        if (typeof jQuery.ui != 'undefined') {
+        if (typeof jQuery.ui !== 'undefined') {
             $("document").ready(function() {
                 /* VARIABLE INIT */
                 alert('jQuery version "' + $.fn.jquery + '" and jQuery UI version "' + $.ui.version + '" are working on this page.');

--- a/core/apps/SdmAuth/SdmAuth.php
+++ b/core/apps/SdmAuth/SdmAuth.php
@@ -13,6 +13,6 @@ switch ($sdmassembler->SdmCoreDetermineRequestedPage()) {
         break;
 
     default:
-        $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<!-- SdmAuth Login Form -->' . 'The login form could not be loaded at this time. Please try again later.<br />-- Page Req : ' . $sdmassembler->SdmCoreDetermineRequestedPage() . '<!-- End SdmAuth Login Form -->', $options);
+        $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<!-- SdmAuth Login Form -->' . 'The login form could not be loaded at this time. Please try again later.<br />-- Page Req : ' . $sdmassembler->SdmCoreDetermineRequestedPage() . '<!-- End SdmAuth Login Form -->', $options);
         break;
 }

--- a/core/apps/SdmAuth/forms/loginForm.php
+++ b/core/apps/SdmAuth/forms/loginForm.php
@@ -3,7 +3,7 @@
 $loginGateKeeper = new SdmGatekeeper();
 // check encrypted LAST_ACTIVITY against $_SESSION['auth_cleared'], if they don't match then user is NOT logged in
 if (SdmGatekeeper::sdmGatekeeperAuthenticate() === true) {
-    $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<!-- SdmAuth Login Form -->' . '<p>Your are currently logged in.</p><p>' . '<span style="font-size:.6em;"><a href="' . $sdmassembler->SdmCoreGetRootDirectoryUrl() . '/index.php?page=SdmAuthLogin&logout=' . session_id() . '">Logout</a></span></p>' . '<!-- End SdmAuth Login Form -->', $options);
+    $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<!-- SdmAuth Login Form -->' . '<p>Your are currently logged in.</p><p>' . '<span style="font-size:.6em;"><a href="' . $sdmassembler->SdmCoreGetRootDirectoryUrl() . '/index.php?page=SdmAuthLogin&logout=' . session_id() . '">Logout</a></span></p>' . '<!-- End SdmAuth Login Form -->', $options);
 } else {
     // Build and display the Login form.
     $loginForm = new SdmForm();
@@ -34,5 +34,5 @@ if (SdmGatekeeper::sdmGatekeeperAuthenticate() === true) {
         ),
     );
     $loginForm->sdmFormBuildForm($sdmassembler->SdmCoreGetRootDirectoryUrl());
-    $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<!-- SdmAuth Login Form -->' . $loginForm->sdmFormGetForm() . '<!-- End SdmAuth Login Form -->', $options);
+    $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<!-- SdmAuth Login Form -->' . $loginForm->sdmFormGetForm() . '<!-- End SdmAuth Login Form -->', $options);
 }

--- a/core/apps/SdmAuth/handlers/SdmAuthLogin.php
+++ b/core/apps/SdmAuth/handlers/SdmAuthLogin.php
@@ -10,16 +10,16 @@ switch (isset($_GET['logout'])) {
     case 'logout':
         session_unset();
         session_destroy();
-        $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<p>Your have been logged out successfully.</p>', $options);
+        $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Your have been logged out successfully.</p>', $options);
         break;
     default:
         // check if login credentials were valid | if they were login user, if not then display login form and a message indicating the login credentials were not valid.
         if ($handler->sdmFormGetSubmittedFormValue('username') === $devUser && $handler->sdmFormGetSubmittedFormValue('password') === $devPass) {
             $_SESSION['sdmauth'] = 'auth';
             $_SESSION['userRole'] = $devUserRole;
-            $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<p>Your are logged in.</p>', $options);
+            $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Your are logged in.</p>', $options);
         } else {
-            $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<p>Invalid Login Credentials</p>', $options);
+            $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Invalid Login Credentials</p>', $options);
             require_once($sdmassembler->SdmCoreGetCoreAppDirectoryPath() . '/SdmAuth/forms/loginForm.php');
         }
         break;

--- a/core/apps/SdmCoreOverview/SdmCoreOverview.php
+++ b/core/apps/SdmCoreOverview/SdmCoreOverview.php
@@ -1,9 +1,13 @@
 <?php
 
-// app description page | if you visit YOURSITE.com/index.php?page=SdmDevMenu this output will be dsiplayed
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h2>Overview of current state the CORE</h2><p>The SDM Core Overview app displays the current state of the SDM CORE.</p>', array('wrapper' => 'main_content', 'incmethod' => 'append', 'incpages' => array('SdmCoreOverview')));
+// options
+$options = array('wrapper' => 'main_content', 'incmethod' => 'append', 'incpages' => array('SdmCoreOverview'));
+// output
+$output = '<h2>Overview of current state the CORE</h2><p>The SDM Core Overview app displays the current state of the SDM CORE.</p>';
 // load the core overview file
-$coredata = $sdmassembler->sdmCoreGetDataObject();
-$output = $sdmassembler->sdmCoreCurlGrabContent($sdmassembler->sdmCoreGetCoreAppDirectoryUrl() . '/SdmCoreOverview/co.php', array('coredata' => $coredata));
+$dataObject = $sdmassembler->sdmCoreGetDataObject();
+if ($sdmassembler->sdmCoreDetermineRequestedPage() === 'SdmCoreOverview') {
+    var_dump($dataObject);
+}
 // incorporate core overview
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, array('wrapper' => 'main_content', 'incpages' => array('SdmCoreOverview')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, $options);

--- a/core/apps/SdmCoreOverview/SdmCoreOverview.php
+++ b/core/apps/SdmCoreOverview/SdmCoreOverview.php
@@ -7,7 +7,9 @@ $output = '<h2>Overview of current state the CORE</h2><p>The SDM Core Overview a
 // load the core overview file
 $dataObject = $sdmassembler->sdmCoreGetDataObject();
 if ($sdmassembler->sdmCoreDetermineRequestedPage() === 'SdmCoreOverview') {
+    ob_start();
     var_dump($dataObject);
+    $output .= ob_get_clean();
 }
 // incorporate core overview
 $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, $options);

--- a/core/apps/SdmCoreOverview/SdmCoreOverview.php
+++ b/core/apps/SdmCoreOverview/SdmCoreOverview.php
@@ -1,9 +1,9 @@
 <?php
 
 // app description page | if you visit YOURSITE.com/index.php?page=SdmDevMenu this output will be dsiplayed
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<h2>Overview of current state the CORE</h2><p>The SDM Core Overview app displays the current state of the SDM CORE.</p>', array('wrapper' => 'main_content', 'incmethod' => 'append', 'incpages' => array('SdmCoreOverview')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h2>Overview of current state the CORE</h2><p>The SDM Core Overview app displays the current state of the SDM CORE.</p>', array('wrapper' => 'main_content', 'incmethod' => 'append', 'incpages' => array('SdmCoreOverview')));
 // load the core overview file
 $coredata = $sdmassembler->sdmCoreGetDataObject();
 $output = $sdmassembler->sdmCoreCurlGrabContent($sdmassembler->sdmCoreGetCoreAppDirectoryUrl() . '/SdmCoreOverview/co.php', array('coredata' => $coredata));
 // incorporate core overview
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, $output, array('wrapper' => 'main_content', 'incpages' => array('SdmCoreOverview')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, array('wrapper' => 'main_content', 'incpages' => array('SdmCoreOverview')));

--- a/core/apps/SdmCoreOverview/co.php
+++ b/core/apps/SdmCoreOverview/co.php
@@ -1,5 +1,0 @@
-<?php
-
-require('../../includes/SdmCore.php');
-$sdmassembler = new SdmCore();
-$sdmassembler->sdmCoreSdmReadArray($_POST['coredata']);

--- a/core/apps/SdmErrorLog/SdmErrorLog.php
+++ b/core/apps/SdmErrorLog/SdmErrorLog.php
@@ -1,13 +1,13 @@
 <?php
 
 // app description page | if you visit YOURSITE.com/index.php?page=SdmDevMenu this output will be dsiplayed
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<h2>Site Errors</h2><p>The SDM Error Log app displays the sites error log and color codes the errors as follows:</p><p style="border:1px solid; border-radius: 20px; color:#DD0000;padding:20px;background:#303030">Fatal</p><p style="border:1px solid; border-radius: 20px; color:#FDD017;padding:20px;background:#000000">Warning</p><p style="border:1px solid; border-radius: 20px; color:#6C7DCC;padding:20px;background:#303030">Notice</p><p style="border:1px solid; border-radius: 20px; color:#FFFFFF;padding:20px;background:#000000">Other</p>', array('wrapper' => 'main_content', 'incmethod' => 'append', 'incpages' => array('SdmErrorLog')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h2>Site Errors</h2><p>The SDM Error Log app displays the sites error log and color codes the errors as follows:</p><p style="border:1px solid; border-radius: 20px; color:#DD0000;padding:20px;background:#303030">Fatal</p><p style="border:1px solid; border-radius: 20px; color:#FDD017;padding:20px;background:#000000">Warning</p><p style="border:1px solid; border-radius: 20px; color:#6C7DCC;padding:20px;background:#303030">Notice</p><p style="border:1px solid; border-radius: 20px; color:#FFFFFF;padding:20px;background:#000000">Other</p>', array('wrapper' => 'main_content', 'incmethod' => 'append', 'incpages' => array('SdmErrorLog')));
 // get the error log with file() so we have each line as an array item. gives us some formating flexablitly later on
 $loaded_error_log = file($sdmassembler->sdmCoreGetCoreDirectoryUrl() . '/logs/sdm_core_errors.log', FILE_IGNORE_NEW_LINES || FILE_SKIP_EMPTY_LINES);
 // reverse the order of the elements because we want the newest errors to be at the top of the list
 $error_log = array_reverse($loaded_error_log);
 // display number of errors
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<p>Number of logged errors : ' . count($error_log) . '</p>', array('incpages' => array('SdmErrorLog')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Number of logged errors : ' . count($error_log) . '</p>', array('incpages' => array('SdmErrorLog')));
 $output = '';
 foreach ($error_log as $error_number => $error_message) {
     $notice_color = '#6C7DCC';
@@ -21,7 +21,7 @@ foreach ($error_log as $error_number => $error_message) {
 $output .= ($output === '' ? '<p style="color:lightgreen;border:1px solid; border-radius: 20px; padding:20px;background:black;">No errors to report.</p>' : '');
 
 // incorporate devmenu
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, $output, array('wrapper' => 'main_content', 'incmethod' => 'append', 'incpages' => array('SdmErrorLog')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, array('wrapper' => 'main_content', 'incmethod' => 'append', 'incpages' => array('SdmErrorLog')));
 
 // clear error form
 $clearErrorsForm = new SdmForm();
@@ -41,12 +41,12 @@ $clearErrorsForm->submitLabel = 'Clear Error Log';
 // build the form
 $clearErrorsForm->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
 // incorporate clear errors form
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, $clearErrorsForm->sdmFormGetForm(), array('wrapper' => 'main_content', 'incmethod' => 'append', 'incpages' => array('SdmErrorLog')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $clearErrorsForm->sdmFormGetForm(), array('wrapper' => 'main_content', 'incmethod' => 'append', 'incpages' => array('SdmErrorLog')));
 if (isset($_POST['SdmForm']) && isset($_POST['SdmForm']['clear_error_log' . $_POST['SdmForm']['form_id']]) && $_POST['SdmForm']['clear_error_log' . $_POST['SdmForm']['form_id']] !== 'clear_error_log' . $clearErrorsForm->sdmFormGetFormId()) {
     //$sdmassembler->sdmCoreSdmReadArray($_POST);
     if (file_put_contents($sdmassembler->sdmCoreGetCoreDirectoryPath() . '/logs/sdm_core_errors.log', trim('')) !== false) {
         $randInt = rand(1000, 9999);
-        $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '
+        $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '
             <!-- this js reloads the page once after the clear error log form is submitted so that the Sdm Error Log page reflects the change. If we did not reload then the old error log could still be shown until the page is reloaded manually | there is still a chance this data may persist for one page load -->
             <script>
               if (sessionStorage.getItem(\'errorLogClearDisplayBugFix\') !== \'fixed\') {

--- a/core/apps/contentManager/contentManager.php
+++ b/core/apps/contentManager/contentManager.php
@@ -20,7 +20,7 @@ $options = array(
 $sdmassembler = $sdmassembler; // see SdmAssembler.php and the app loading methods
 if (substr($sdmassembler->sdmCoreDetermineRequestedPage(), 0, 14) === 'contentManager') {
     // CREATE A NEW CONTENT MANAGEMENT OBJECT
-    $sdmcms = SdmCms::sdmCmsInitializeCms();
+    $sdmcms = new SdmCms();
     // determine which section of the content manager was requested
     switch ($sdmassembler->sdmCoreDetermineRequestedPage()) {
         // edit content form
@@ -65,7 +65,7 @@ if (substr($sdmassembler->sdmCoreDetermineRequestedPage(), 0, 14) === 'contentMa
             break;
         default:
             // present content manager menu
-            $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '
+            $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '
                 <div id="contentManager">
                 <p>Welcome to the Content Manager. Here you can create, edit, delete, and restore content</p>
                     <ul>

--- a/core/apps/contentManager/forms/contentManagerAddContentForm.php
+++ b/core/apps/contentManager/forms/contentManagerAddContentForm.php
@@ -42,4 +42,4 @@ foreach ($sdmcms->sdmCmsDetermineAvailableWrappers() as $displayValue => $machin
 }
 $editcontentform->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
 // add form to content
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);

--- a/core/apps/contentManager/forms/contentManagerAdministerAppsForm.php
+++ b/core/apps/contentManager/forms/contentManagerAdministerAppsForm.php
@@ -44,4 +44,4 @@ foreach ($available_apps as $displayValue => $machineValue) {
 
 $editcontentform->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
 // add form to content
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);

--- a/core/apps/contentManager/forms/contentManagerEditContentForm.php
+++ b/core/apps/contentManager/forms/contentManagerEditContentForm.php
@@ -61,4 +61,4 @@ foreach ($sdmcms->sdmCmsDetermineAvailableWrappers() as $displayValue => $machin
 
 $editcontentform->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
 // add form to content
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<!-- contentManager Edit Content Form --><p><i>You are currently editing the <b>' . ucwords($pagetoedit) . '</b></i></p>' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<!-- contentManager Edit Content Form --><p><i>You are currently editing the <b>' . ucwords($pagetoedit) . '</b></i></p>' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);

--- a/core/apps/contentManager/forms/contentManagerSelectPageToDeleteForm.php
+++ b/core/apps/contentManager/forms/contentManagerSelectPageToDeleteForm.php
@@ -30,4 +30,4 @@ $editcontentform->form_elements = array(
 
 $editcontentform->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
 // add form to content
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);

--- a/core/apps/contentManager/forms/contentManagerSelectPageToEditForm.php
+++ b/core/apps/contentManager/forms/contentManagerSelectPageToEditForm.php
@@ -30,4 +30,4 @@ $editcontentform->form_elements = array(
 
 $editcontentform->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
 // add form to content
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);

--- a/core/apps/contentManager/forms/contentManagerSelectThemeForm.php
+++ b/core/apps/contentManager/forms/contentManagerSelectThemeForm.php
@@ -36,4 +36,4 @@ $editcontentform->form_elements = array(
 
 $editcontentform->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
 // add form to content
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);

--- a/core/apps/contentManager/handlers/contentManagerAdministerAppsFormSubmission.php
+++ b/core/apps/contentManager/handlers/contentManagerAdministerAppsFormSubmission.php
@@ -42,4 +42,4 @@ else {
                 ';
 }
 
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, $output, $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, $options);

--- a/core/apps/contentManager/handlers/contentManagerDeletePageSubmission.php
+++ b/core/apps/contentManager/handlers/contentManagerDeletePageSubmission.php
@@ -27,4 +27,4 @@ else {
                 ';
 }
 
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, $output, $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, $options);

--- a/core/apps/contentManager/handlers/contentManagerSelectThemeFormSubmission.php
+++ b/core/apps/contentManager/handlers/contentManagerSelectThemeFormSubmission.php
@@ -25,4 +25,4 @@ else {
                 ';
 }
 
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, $output, $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, $options);

--- a/core/apps/contentManager/handlers/contentManagerUpdateContentFormSubmission.php
+++ b/core/apps/contentManager/handlers/contentManagerUpdateContentFormSubmission.php
@@ -36,4 +36,4 @@ if ($sdmForm->sdmFormGetSubmittedFormValue('page') !== 'contentManager') {
 } else {
     $output = '<p>Page could not be created because pages cannot use the name "contentManager" for security reasons. You can however add a page for one of the content managers stages.</p>';
 }
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, $output, $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, $options);

--- a/core/apps/navigationManager/navigationManager.php
+++ b/core/apps/navigationManager/navigationManager.php
@@ -43,7 +43,7 @@ $options = array(
 $sdmassembler = $sdmassembler; // see SdmAssembler.php
 if (substr($sdmassembler->sdmCoreDetermineRequestedPage(), 0, 17) === 'navigationManager') {
     // CREATE A NEW CONTENT MANAGEMENT OBJECT
-    $sdmcms = SdmCms::sdmCmsInitializeCms();
+    $sdmcms = new SdmCms();
     // determine which section of the content manager was requested
     switch ($sdmassembler->sdmCoreDetermineRequestedPage()) {
         // Add Menu Stages
@@ -96,7 +96,7 @@ if (substr($sdmassembler->sdmCoreDetermineRequestedPage(), 0, 17) === 'navigatio
             break;
         default:
             // present content manager menu
-            $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '
+            $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '
                 <div id="navigationManager">
                 <p>Welcome to the Navigation Manager. Here you can create, edit, delete, and restore menus</p>
                     <ul>

--- a/core/apps/navigationManager/stages/addmenustage1.php
+++ b/core/apps/navigationManager/stages/addmenustage1.php
@@ -26,4 +26,4 @@ $addMenuFormStage1->form_elements = array(
     ),
 );
 $addMenuFormStage1->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<h3>How many menu items will this menu have?</h3>' . $addMenuFormStage1->sdmFormGetForm(), array('incpages' => array('navigationManagerAddMenuStage1')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>How many menu items will this menu have?</h3>' . $addMenuFormStage1->sdmFormGetForm(), array('incpages' => array('navigationManagerAddMenuStage1')));

--- a/core/apps/navigationManager/stages/addmenustage2.php
+++ b/core/apps/navigationManager/stages/addmenustage2.php
@@ -141,7 +141,7 @@ switch (SdmForm::sdmFormGetSubmittedFormValue('menuItem') !== null) {
             // add the last submitted menu item to our menu items array
             array_push($addMenuFormStage2->form_elements, $mi);
             // display of preview of the menu so far
-            $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<div style="border:2px solid #777777;border-radius:9px;padding:20px;height:120px;overflow:auto;"><h3>Last Submitted Menu Item:</h3><p>Display Name: <span style="color:blue;">' . SdmForm::sdmFormGetSubmittedFormValue('menuItemDisplayName') . '</span> | Destination Type : <span style="color:blue;">' . $lastSubmittedMenuItem->destinationType . '</span> | Destination: <span style="color:blue;">' . $lastSubmittedMenuItem->destination . '</span></p><h3>Menu Preview:</h3>' . $sdmnms->sdmNmsBuildMenuItemsHtml($menuItems) . '</div>', array('incmethod' => 'prepend', 'incpages' => $options['incpages']));
+            $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<div style="border:2px solid #777777;border-radius:9px;padding:20px;height:120px;overflow:auto;"><h3>Last Submitted Menu Item:</h3><p>Display Name: <span style="color:blue;">' . SdmForm::sdmFormGetSubmittedFormValue('menuItemDisplayName') . '</span> | Destination Type : <span style="color:blue;">' . $lastSubmittedMenuItem->destinationType . '</span> | Destination: <span style="color:blue;">' . $lastSubmittedMenuItem->destination . '</span></p><h3>Menu Preview:</h3>' . $sdmnms->sdmNmsBuildMenuItemsHtml($menuItems) . '</div>', array('incmethod' => 'prepend', 'incpages' => $options['incpages']));
         } else {
             $menuItems = array();
             $mi = array(
@@ -154,10 +154,10 @@ switch (SdmForm::sdmFormGetSubmittedFormValue('menuItem') !== null) {
             array_push($addMenuFormStage2->form_elements, $mi);
         }
         $addMenuFormStage2->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
-        $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<h3>Configure Menu Items</h3>' . $addMenuFormStage2->sdmFormGetForm(), array('incpages' => array('navigationManagerAddMenuStage2')));
+        $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>Configure Menu Items</h3>' . $addMenuFormStage2->sdmFormGetForm(), array('incpages' => array('navigationManagerAddMenuStage2')));
         break;
 
     default:
-        $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<p>An error occured and the form could not be submitted. Please report this to the site admin. <a href="' . $sdmassembler->sdmCoreGetRootDirectoryUrl() . '/index.php?page=homepage">Return to the Homepage</a></p>', array('incpages' => array('navigationManagerAddMenuStage2')));
+        $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>An error occured and the form could not be submitted. Please report this to the site admin. <a href="' . $sdmassembler->sdmCoreGetRootDirectoryUrl() . '/index.php?page=homepage">Return to the Homepage</a></p>', array('incpages' => array('navigationManagerAddMenuStage2')));
         break;
 }

--- a/core/apps/navigationManager/stages/addmenustage3.php
+++ b/core/apps/navigationManager/stages/addmenustage3.php
@@ -24,7 +24,7 @@ $finalSubmittedMenuItem->menuItemWrappingTagType = SdmForm::sdmFormGetSubmittedF
 // add the last submitted menu item to our menu items array
 $menuItems[$finalSubmittedMenuItem->menuItemId] = $finalSubmittedMenuItem;
 // display of preview of the menu so far
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<div style="border:2px solid #777777;border-radius:9px;padding:20px;height:120px;overflow:auto;"><h3>Last Submitted Menu Item:</h3><p>Display Name: <span style="color:blue;">' . SdmForm::sdmFormGetSubmittedFormValue('menuItemDisplayName') . '</span> | Destination Type : <span style="color:blue;">' . $finalSubmittedMenuItem->destinationType . '</span> | Destination: <span style="color:blue;">' . $finalSubmittedMenuItem->destination . '</span></p><h3>Menu Preview:</h3>' . $sdmnms->sdmNmsBuildMenuItemsHtml($menuItems) . '</div>', array('incmethod' => 'prepend', 'incpages' => $options['incpages']));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<div style="border:2px solid #777777;border-radius:9px;padding:20px;height:120px;overflow:auto;"><h3>Last Submitted Menu Item:</h3><p>Display Name: <span style="color:blue;">' . SdmForm::sdmFormGetSubmittedFormValue('menuItemDisplayName') . '</span> | Destination Type : <span style="color:blue;">' . $finalSubmittedMenuItem->destinationType . '</span> | Destination: <span style="color:blue;">' . $finalSubmittedMenuItem->destination . '</span></p><h3>Menu Preview:</h3>' . $sdmnms->sdmNmsBuildMenuItemsHtml($menuItems) . '</div>', array('incmethod' => 'prepend', 'incpages' => $options['incpages']));
 $addMenuFormStage3 = new SdmForm();
 $addMenuFormStage3->form_handler = 'navigationManagerAddMenuStage4';
 $addMenuFormStage3->form_method = 'post';
@@ -102,5 +102,5 @@ $addMenuFormStage3->form_elements = array(
     ),
 );
 $addMenuFormStage3->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, $addMenuFormStage3->sdmFormGetForm(), array('incpages' => array('navigationManagerAddMenuStage3')));
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<h3>Configure Menu</h3>', array('incmethod' => 'prepend', 'incpages' => array('navigationManagerAddMenuStage3')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $addMenuFormStage3->sdmFormGetForm(), array('incpages' => array('navigationManagerAddMenuStage3')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>Configure Menu</h3>', array('incmethod' => 'prepend', 'incpages' => array('navigationManagerAddMenuStage3')));

--- a/core/apps/navigationManager/stages/addmenustage4.php
+++ b/core/apps/navigationManager/stages/addmenustage4.php
@@ -13,5 +13,5 @@ $menu->menuPlacement = SdmForm::sdmFormGetSubmittedFormValue('menuPlacement'); /
 $menu->menuWrappingTagType = SdmForm::sdmFormGetSubmittedFormValue('menuWrappingTagType'); //
 $menu->wrapper = SdmForm::sdmFormGetSubmittedFormValue('wrapper'); //
 $sdmnms->sdmNmsAddMenu($menu);
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<p>Menu Added Successfully (Still in Dev, Does not necessarily indicate succsessful menu add yet)</p>', array('incpages' => array('navigationManagerAddMenuStage4')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Menu Added Successfully (Still in Dev, Does not necessarily indicate succsessful menu add yet)</p>', array('incpages' => array('navigationManagerAddMenuStage4')));
 

--- a/core/apps/navigationManager/stages/deletemenustage1.php
+++ b/core/apps/navigationManager/stages/deletemenustage1.php
@@ -17,7 +17,7 @@ if (!empty($availableMenus) === true) {
     $deleteMenuFormStage1->submitLabel = 'Delete Menu';
     $deleteMenuFormStage1->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
 
-    $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<h3>Delete Menu</h3>' . $deleteMenuFormStage1->sdmFormGetForm(), array('incpages' => array('navigationManagerDeleteMenuStage1')));
+    $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>Delete Menu</h3>' . $deleteMenuFormStage1->sdmFormGetForm(), array('incpages' => array('navigationManagerDeleteMenuStage1')));
 } else {
-    $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<h3>Delete Menu</h3><p>There are no menus to delete.</p>', array('incpages' => array('navigationManagerDeleteMenuStage1')));
+    $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>Delete Menu</h3><p>There are no menus to delete.</p>', array('incpages' => array('navigationManagerDeleteMenuStage1')));
 }

--- a/core/apps/navigationManager/stages/deletemenustage2.php
+++ b/core/apps/navigationManager/stages/deletemenustage2.php
@@ -1,4 +1,4 @@
 <?php
 
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<h3>Deleted Menu:</h3>' . $sdmnms->sdmNmsDeleteMenu(SdmForm::sdmFormGetSubmittedFormValue('menuId')), array('incpages' => array('navigationManagerDeleteMenuStage2')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>Deleted Menu:</h3>' . $sdmnms->sdmNmsDeleteMenu(SdmForm::sdmFormGetSubmittedFormValue('menuId')), array('incpages' => array('navigationManagerDeleteMenuStage2')));
 ?>

--- a/core/apps/navigationManager/stages/editmenustage1.php
+++ b/core/apps/navigationManager/stages/editmenustage1.php
@@ -16,7 +16,7 @@ if (!empty($availableMenus) === true) {
         ),
     );
     $editMenuSelectMenuForm->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
-    $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<h3>Which menu do you wish to edit?</h3>' . $editMenuSelectMenuForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage1')));
+    $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>Which menu do you wish to edit?</h3>' . $editMenuSelectMenuForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage1')));
 } else {
-    $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<h3>There are no menus to edit.</h3>', array('incpages' => array('navigationManagerEditMenuStage1')));
+    $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>There are no menus to edit.</h3>', array('incpages' => array('navigationManagerEditMenuStage1')));
 }

--- a/core/apps/navigationManager/stages/editmenustage2.php
+++ b/core/apps/navigationManager/stages/editmenustage2.php
@@ -125,4 +125,4 @@ foreach ($menuItems as $menuItem) {
 $output .= '</ul></div>';
 $addMenuItemArguments = array('page=navigationManagerEditMenuStage3_addmenuitem', 'menuId=' . $menu->menuId, 'linkedBy=navigationManager_editmenustage2_addMenuItemLink');
 $output .= '<p><a href="' . $sdmassembler->sdmCoreGetRootDirectoryUrl() . '/index.php?' . str_replace('%26', '&', str_replace('%3D', '=', urlencode(implode('&', $addMenuItemArguments)))) . '">Add Menu Item</a></p>';
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, $output . '<h3>Menu Settings</h3>' . $editMenuSelectMenuForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage2')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output . '<h3>Menu Settings</h3>' . $editMenuSelectMenuForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage2')));

--- a/core/apps/navigationManager/stages/editmenustage3_addmenuitem.php
+++ b/core/apps/navigationManager/stages/editmenustage3_addmenuitem.php
@@ -107,4 +107,4 @@ $addMenuItemForm->form_elements = array(
     ),
 );
 $addMenuItemForm->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, $addMenuItemForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage3_addmenuitem')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $addMenuItemForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage3_addmenuitem')));

--- a/core/apps/navigationManager/stages/editmenustage3_confirmdeletemenuitem.php
+++ b/core/apps/navigationManager/stages/editmenustage3_confirmdeletemenuitem.php
@@ -45,4 +45,4 @@ $cancelForm->form_elements = array(
     ),
 );
 $cancelForm->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<p>Are you sure you wish to delete menu item "<b>' . $menuItemName . '</b>" with id "<b>' . $menuItemId . '</b>" from menu "<b>' . $menuName . '</b>" with id "<b>' . $menuId . '</b>"?</p>' . $deleteForm->sdmFormGetForm() . $cancelForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage3_confirmdeletemenuitem')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Are you sure you wish to delete menu item "<b>' . $menuItemName . '</b>" with id "<b>' . $menuItemId . '</b>" from menu "<b>' . $menuName . '</b>" with id "<b>' . $menuId . '</b>"?</p>' . $deleteForm->sdmFormGetForm() . $cancelForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage3_confirmdeletemenuitem')));

--- a/core/apps/navigationManager/stages/editmenustage3_deletemenuitem.php
+++ b/core/apps/navigationManager/stages/editmenustage3_deletemenuitem.php
@@ -9,4 +9,4 @@ $menuName = $menu->menuDisplayName;
 $menuItemName = $menu->menuItems->$menuItemId->menuItemDisplayName;
 // delete the menu item
 $sdmnms->sdmNmsDeleteMenuItem($menuId, $menuItemId);
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<p>Deleted menu item "<b>' . $menuItemName . '</b>" with id "<b>' . $menuItemId . '</b>" from menu "<b>' . $menuName . '</b>" with id "<b>' . $menuId . '</b>".</p>', array('incpages' => array('navigationManagerEditMenuStage3_deletemenuitem')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Deleted menu item "<b>' . $menuItemName . '</b>" with id "<b>' . $menuItemId . '</b>" from menu "<b>' . $menuName . '</b>" with id "<b>' . $menuId . '</b>".</p>', array('incpages' => array('navigationManagerEditMenuStage3_deletemenuitem')));

--- a/core/apps/navigationManager/stages/editmenustage3_editmenuitem.php
+++ b/core/apps/navigationManager/stages/editmenustage3_editmenuitem.php
@@ -107,4 +107,4 @@ $editMenuItemForm->form_elements = array(
     ),
 );
 $editMenuItemForm->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, $editMenuItemForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage3_editmenuitem')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $editMenuItemForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage3_editmenuitem')));

--- a/core/apps/navigationManager/stages/editmenustage3_submitaddmenuitem.php
+++ b/core/apps/navigationManager/stages/editmenustage3_submitaddmenuitem.php
@@ -15,4 +15,4 @@ $submittedMenuItem->menuItemMachineName = SdmCore::SdmCoreGenerateMachineName(Sd
 $submittedMenuItem->menuItemPosition = SdmForm::sdmFormGetSubmittedFormValue('menuItemPosition');
 $submittedMenuItem->menuItemWrappingTagType = SdmForm::sdmFormGetSubmittedFormValue('menuItemWrappingTagType');
 $sdmnms->sdmNmsAddMenuItem(SdmForm::sdmFormGetSubmittedFormValue('menuId'), $submittedMenuItem);
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<p>Menu Item Edits Saved Successfully</p>', array('incpages' => array('navigationManagerEditMenuStage3_submitaddmenuitem')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Menu Item Edits Saved Successfully</p>', array('incpages' => array('navigationManagerEditMenuStage3_submitaddmenuitem')));

--- a/core/apps/navigationManager/stages/editmenustage3_submitmenuchanges.php
+++ b/core/apps/navigationManager/stages/editmenustage3_submitmenuchanges.php
@@ -13,4 +13,4 @@ $menu->menuPlacement = SdmForm::sdmFormGetSubmittedFormValue('menuPlacement'); /
 $menu->menuWrappingTagType = SdmForm::sdmFormGetSubmittedFormValue('menuWrappingTagType'); //
 $menu->wrapper = SdmForm::sdmFormGetSubmittedFormValue('wrapper'); //
 $sdmnms->sdmNmsUpdateMenu($menu->menuId, $menu);
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<p>Menu Edits Saved Successfully</p>', array('incpages' => array('navigationManagerEditMenuStage3_submitmenuchanges')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Menu Edits Saved Successfully</p>', array('incpages' => array('navigationManagerEditMenuStage3_submitmenuchanges')));

--- a/core/apps/navigationManager/stages/editmenustage3_submitmenuitemchanges.php
+++ b/core/apps/navigationManager/stages/editmenustage3_submitmenuitemchanges.php
@@ -15,4 +15,4 @@ $submittedMenuItem->menuItemMachineName = SdmCore::SdmCoreGenerateMachineName(Sd
 $submittedMenuItem->menuItemPosition = SdmForm::sdmFormGetSubmittedFormValue('menuItemPosition');
 $submittedMenuItem->menuItemWrappingTagType = SdmForm::sdmFormGetSubmittedFormValue('menuItemWrappingTagType');
 $sdmnms->sdmNmsUpdateMenuItem(SdmForm::sdmFormGetSubmittedFormValue('menuId'), $submittedMenuItem->menuItemId, $submittedMenuItem);
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, '<p>Menu Item Edits Saved Successfully</p>', array('incpages' => array('navigationManagerEditMenuStage3_submitmenuitemchanges')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Menu Item Edits Saved Successfully</p>', array('incpages' => array('navigationManagerEditMenuStage3_submitmenuitemchanges')));

--- a/core/config/startup.php
+++ b/core/config/startup.php
@@ -10,14 +10,10 @@ function __autoload($classes) {
 }
 
 // create/configure core
-$sdmcore = new SdmCore;
+$sdmassembler = new SdmAssembler;
 // configure core
-$sdmcore->sdmCoreConfigureCore();
-// startup the gatekeeper
-$sdmGatekeeper = new SdmGatekeeper();
+$sdmassembler->sdmCoreConfigureCore();
 // start core session
-$sdmGatekeeper->sessionStart();
-// initialize assembler
-$sdmassembler = new SdmAssembler();
+$sdmassembler->sessionStart();
 // load and assemble content | this var is used excluisively by the current themes page.php
 $sdmAssemblerThemeContentObject = $sdmassembler->sdmAssemblerLoadAndAssembleContentObject();

--- a/core/config/startup.php
+++ b/core/config/startup.php
@@ -20,4 +20,4 @@ $sdmGatekeeper->sessionStart();
 // initialize assembler
 $sdmassembler = new SdmAssembler();
 // load and assemble content | this var is used excluisively by the current themes page.php
-$sdmassembler_themeContentObject = $sdmassembler->sdmAssemblerLoadAndAssembleContentObject();
+$sdmAssemblerThemeContentObject = $sdmassembler->sdmAssemblerLoadAndAssembleContentObject();

--- a/core/includes/SdmAssembler.php
+++ b/core/includes/SdmAssembler.php
@@ -9,7 +9,7 @@
  *
  * @author foremase
  */
-class SdmAssembler extends SdmCore {
+class SdmAssembler extends SdmGatekeeper {
 
     /**
      * <p>Returns the HTML header for the page as a string. The SdmAssembler will give apps

--- a/core/includes/SdmAssembler.php
+++ b/core/includes/SdmAssembler.php
@@ -180,15 +180,15 @@ class SdmAssembler extends SdmCore {
     public function sdmAssemblerLoadAndAssembleContentObject() {
         $page = $this->sdmCoreDetermineRequestedPage();
         // load our data object
-        $sdmassembler_dataObject = $this->sdmCoreGetDataObject();
+        $sdmAssemblerDataObject = $this->sdmCoreGetDataObject();
         // load and assemble apps
-        $this->sdmAssemblerLoadApps($sdmassembler_dataObject);
+        $this->sdmAssemblerLoadApps($sdmAssemblerDataObject);
         // make sure content exists, if it does return it, if not, return a content not found message and log the bad request to the bad requests log
-        switch (isset($sdmassembler_dataObject->content->$page)) {
+        switch (isset($sdmAssemblerDataObject->content->$page)) {
             case true:
-                //var_dump($sdmassembler_dataObject->content->$page);
-                $sdmassembler_dataObject = $this->sdmAssemblerPreparePageForDisplay($sdmassembler_dataObject->content->$page);
-                return $sdmassembler_dataObject;
+                //var_dump($sdmAssemblerDataObject->content->$page);
+                $sdmAssemblerDataObject = $this->sdmAssemblerPreparePageForDisplay($sdmAssemblerDataObject->content->$page);
+                return $sdmAssemblerDataObject;
             default:
                 // log bad request to our badRequestsLog.log file
                 $badRequestId = chr(rand(65, 90)) . rand(10, 99) . chr(rand(65, 90)) . rand(10, 99);
@@ -230,16 +230,16 @@ class SdmAssembler extends SdmCore {
 
     /**
      * Loads enabled apps.
-     * @param object $sdmassembler_dataObject <p>The Content object for the requested page.</p>
+     * @param object $sdmAssemblerDataObject <p>The Content object for the requested page.</p>
      * @return bool <p>false if any apps failed to load, true if no problems occured when loading
      * all apps.</p><p><b>NOTE</b>:<i>This method will return true even if this methods call to
      * $this->sdmAssemblerLoadApp() fails to load an app as a result of user having insufficient
      * privlages. Only actual failures will result in this method returning false.</i></p>
      */
-    private function sdmAssemblerLoadApps($sdmassembler_dataObject) {
+    private function sdmAssemblerLoadApps($sdmAssemblerDataObject) {
         $enabledApps = $this->sdmCoreDetermineEnabledApps();
         foreach ($enabledApps as $app) {
-            $status[] = $this->sdmAssemblerLoadApp($app, $sdmassembler_dataObject);
+            $status[] = $this->sdmAssemblerLoadApp($app, $sdmAssemblerDataObject);
         }
         return (in_array(false, $status, true));
     }
@@ -252,7 +252,7 @@ class SdmAssembler extends SdmCore {
      * of an error, such as the app not being found, or the string 'accessDenied' if app was
      * not loaded as a result of user not having sufficient privlages to use app.</p>
      */
-    private function sdmAssemblerLoadApp($app, $sdmassembler_dataObject) {
+    private function sdmAssemblerLoadApp($app, $sdmAssemblerDataObject) {
         // store SdmAssembler object in an appropriatly named var to give apps easy access
         $sdmassembler = $this;
         // read app gatekeeper parameters
@@ -280,7 +280,7 @@ class SdmAssembler extends SdmCore {
             return false;
         }
         // user does not have permission to use this app
-        $this->sdmAssemblerIncorporateAppOutput($sdmassembler_dataObject, 'You do not have permission to be here.', array('incpages' => array($app)));
+        $this->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, 'You do not have permission to be here.', array('incpages' => array($app)));
         return 'accessDenied';
     }
 
@@ -317,7 +317,7 @@ class SdmAssembler extends SdmCore {
      * <br /><br />i.e, http://example.com/index.php?page=NonExistentPage would work if we did not check for it in CORE
      * and in the 'incpages' array</p>
      * @param object $dataObject <p style="font-size:9px;">The sites data object. (This is most likely the
-     * $sdmassembler_dataObject var provided by the SDM_Assembler)<br />
+     * $sdmAssemblerDataObject var provided by the SDM_Assembler)<br />
      * Note: We need to typehint for security, however PHP has no common
      * object ancestor so we cant specify <i>object</i> because most likely
      * the type of this argument will be an instance of stdClass, which is
@@ -462,16 +462,16 @@ class SdmAssembler extends SdmCore {
      * <p>Assembles the html content for a given $wrapper and returns it as a string. This method
      * is meant to be called from within a themes page.php file.</p>
      * @param string $wrapper <p>The wrapper to assemble html</p>
-     * @param stdClass $dataObject <p>The $sdmassembler_themeContentObject variable that is created
+     * @param stdClass $dataObject <p>The $sdmAssemblerThemeContentObject variable that is created
      * by startup.php's call to SdmAssembler::sdmAssemblerLoadAndAssembleContentObject() during the
-     * startup process. The $sdmassembler_themeContentObject is always avaialbe to all themes.
+     * startup process. The $sdmAssemblerThemeContentObject is always avaialbe to all themes.
      * <br>See: <i>/core/config/startup.php</i> for more info</p>
      * @return type
      */
-    public static function sdmAssemblerGetContentHtml($wrapper, stdClass $sdmassembler_themeContentObject) {
+    public static function sdmAssemblerGetContentHtml($wrapper, stdClass $sdmAssemblerThemeContentObject) {
         // initialize the SdmNms so we can add our menus to the page.
         $nms = new SdmNms();
-        $wrapperAssembledContent = (isset($sdmassembler_themeContentObject->$wrapper) ? $sdmassembler_themeContentObject->$wrapper : '<!-- ' . $wrapper . ' placeholder -->');
+        $wrapperAssembledContent = (isset($sdmAssemblerThemeContentObject->$wrapper) ? $sdmAssemblerThemeContentObject->$wrapper : '<!-- ' . $wrapper . ' placeholder -->');
         $content = $nms->sdmNmsGetWrapperMenusHtml($wrapper, $wrapperAssembledContent);
         return $content;
     }

--- a/core/includes/SdmCms.php
+++ b/core/includes/SdmCms.php
@@ -143,17 +143,6 @@ class SdmCms extends SdmCore {
         return $available_apps;
     }
 
-    /** MOVED TO CORE
-     * <p>Determines what apps are enabled by checking the property
-     * values of the Enabled Apps object</p>
-     * @return object An object whose properties are apps that are currently enabled.
-     */
-//    public function sdmCoreDetermineEnabledApps() {
-//        $data = $this->sdmCoreGetDataObject();
-//        $enabled_apps = $data->settings->enabledapps;
-//        return $enabled_apps;
-//    }
-
     /**
      * Switches an app from on to off.
      * @param string $app <p>Name of the app to switch on or of.</p>

--- a/core/includes/SdmCms.php
+++ b/core/includes/SdmCms.php
@@ -8,15 +8,6 @@
  */
 class SdmCms extends SdmCore {
 
-    private static $Initialized;
-
-    public static function sdmCmsInitializeCms() {
-        if (!isset(self::$Initialized)) {
-            self::$Initialized = new SdmCms;
-        }
-        return self::$Initialized;
-    }
-
     /**
      * <p>Creates content for a specific page ($page) and content wrapper ($id)</p>
      * <p><b>Warning: This method will overwrite content if it already exists.
@@ -36,14 +27,14 @@ class SdmCms extends SdmCore {
     public function sdmCmsUpdateContent($page, $id, $html) {
         $content = $this->sdmCoreGetDataObject();
         // filter out problematic charaters from $html and insure UTF-8 using iconv()
-        $filtered_html = iconv("UTF-8", "UTF-8//IGNORE", $html);
-        $filtered_html2 = iconv("UTF-8", "ISO-8859-1//IGNORE", $filtered_html);
-        $filtered_html3 = iconv("ISO-8859-1", "UTF-8", $filtered_html2);
+        $filteredHtml = iconv("UTF-8", "UTF-8//IGNORE", $html);
+        $filteredHtml2 = iconv("UTF-8", "ISO-8859-1//IGNORE", $filteredHtml);
+        $filteredHtml3 = iconv("ISO-8859-1", "UTF-8", $filteredHtml2);
         // if the page does not already exist in CORE create a placeholder object for it
         if (!isset($content->content->$page) === true) {
             $content->content->$page = new stdClass();
         }
-        $content->content->$page->$id = htmlentities(utf8_encode(trim($filtered_html3)), ENT_SUBSTITUTE | ENT_DISALLOWED | ENT_HTML5, 'UTF-8');
+        $content->content->$page->$id = htmlentities(utf8_encode(trim($filteredHtml3)), ENT_SUBSTITUTE | ENT_DISALLOWED | ENT_HTML5, 'UTF-8');
         $data = json_encode($content);
         return file_put_contents($this->sdmCoreGetDataDirectoryPath() . '/data.json', $data, LOCK_EX);
     }
@@ -98,10 +89,10 @@ class SdmCms extends SdmCore {
         $ignore = array('.DS_Store', '.', '..');
         foreach ($themes as $theme) {
             if (!in_array($theme, $ignore)) {
-                $available_themes[ucwords(preg_replace('/(?<!\ )[A-Z]/', ' $0', $theme))] = $theme;
+                $availableThemes[ucwords(preg_replace('/(?<!\ )[A-Z]/', ' $0', $theme))] = $theme;
             }
         }
-        return $available_themes;
+        return $availableThemes;
     }
 
     /**
@@ -138,9 +129,9 @@ class SdmCms extends SdmCore {
      * </p>
      */
     public function sdmCmsDetermineAvailableApps() {
-        $user_apps = $this->sdmCoreGetDirectoryListing('', 'userapps');
-        $core_apps = $this->sdmCoreGetDirectoryListing('', 'coreapps');
-        $apps = array_merge($user_apps, $core_apps);
+        $userApps = $this->sdmCoreGetDirectoryListing('', 'userapps');
+        $coreApps = $this->sdmCoreGetDirectoryListing('', 'coreapps');
+        $apps = array_merge($userApps, $coreApps);
 
         // we dont want to list directories that are not apps
         $ignore = array('.DS_Store', '.', '..');

--- a/core/includes/SdmCore.php
+++ b/core/includes/SdmCore.php
@@ -238,9 +238,20 @@ class SdmCore {
      * @return object <p>The content object loaded from $this->CoreDirectoryUrl/sdm/data.json or from the DB</p>
      */
     final public function sdmCoreLoadDataObject() {
+        $reqPage = $this->sdmCoreDetermineRequestedPage();
         $coreData = $this->sdmCoreCurlGrabContent($this->sdmCoreGetDataDirectoryUrl() . '/data.json');
         $data = json_decode($coreData);
-        return $data;
+        // filter out pages that are not the current page from core data so the Data Object is not so large. Also, for security reasons we don't want to pass around a DataObject that holds all pages content because it could put restricted content at risk of being discovered by mistake, for instance by a call to var_dump() in a user app that is not properly configured to restrict accses.
+        $dataObject = new stdClass(); // at some point a DataObject class should be created to define the basic structure of a DataObject
+        if (isset($data->content->$reqPage) === TRUE) {
+            $dataObject->content->$reqPage = $data->content->$reqPage;
+        }
+        if (!isset($dataObject->content)) {
+            $dataObject->content = new stdClass();
+        }
+        $dataObject->settings = $data->settings;
+        $dataObject->menus = $data->menus;
+        return $dataObject;
     }
 
     /**

--- a/core/includes/SdmCore.php
+++ b/core/includes/SdmCore.php
@@ -323,8 +323,8 @@ class SdmCore {
     }
 
     /**
-     *  Attempts to return a directory listing for the specified directory (i.e., $directory_name)
-     * @param string $directory_name <p>The name of the directory to create a listing of.</p>
+     *  Attempts to return a directory listing for the specified directory (i.e., $directoryName)
+     * @param string $directoryName <p>The name of the directory to create a listing of.</p>
      * @param string $directoryLocationReference <p>The name of a directory to be used as a starting reference point to search for the directory we want to create a listing for.
      * <br><br>
      * <i>$this->sdmCoreGetDirectoryListing('', 'core')</i>
@@ -332,33 +332,33 @@ class SdmCore {
      * would return a directory listing for '<b>SITESROOTURL</b>/core/'. (Note: passing an empty string will return the name of the directory being used as a locational reference.(i.e., $directoryLocationReference)
      * <br><br><b>(Note: there is one special value you can pass to this parameter, the 'CURRENT_THEME' value will return a directory listing for the current theme)</b>
      * </p>
-     * @return array A directory listing for $directory_name as an array.
+     * @return array A directory listing for $directoryName as an array.
      */
-    final public function sdmCoreGetDirectoryListing($directory_name, $directoryLocationReference) {
+    final public function sdmCoreGetDirectoryListing($directoryName, $directoryLocationReference) {
         switch ($directoryLocationReference) {
             // search for directory in site root
             case 'root':
-                return scandir($this->sdmCoreGetRootDirectoryPath() . '/' . $directory_name);
+                return scandir($this->sdmCoreGetRootDirectoryPath() . '/' . $directoryName);
                 break;
             // search for directory in site core
             case 'core':
-                return scandir($this->sdmCoreGetCoreDirectoryPath() . '/' . $directory_name);
+                return scandir($this->sdmCoreGetCoreDirectoryPath() . '/' . $directoryName);
                 break;
             // search for directory in site themes
             case 'themes':
-                return scandir($this->sdmCoreGetRootDirectoryPath() . '/themes/' . $directory_name);
+                return scandir($this->sdmCoreGetRootDirectoryPath() . '/themes/' . $directoryName);
                 break;
             case 'CURRENT_THEME':
-                return scandir($this->sdmCoreGetCurrentThemeDirectoryPath() . '/' . $directory_name);
+                return scandir($this->sdmCoreGetCurrentThemeDirectoryPath() . '/' . $directoryName);
                 break;
             case 'apps':
-                return scandir($this->sdmCoreGetUserAppDirectoryPath() . '/' . $directory_name);
+                return scandir($this->sdmCoreGetUserAppDirectoryPath() . '/' . $directoryName);
                 break;
             case 'coreapps':
-                return scandir($this->sdmCoreGetCoreAppDirectoryPath() . '/' . $directory_name);
+                return scandir($this->sdmCoreGetCoreAppDirectoryPath() . '/' . $directoryName);
                 break;
             case 'userapps':
-                return scandir($this->sdmCoreGetUserAppDirectoryPath() . '/' . $directory_name);
+                return scandir($this->sdmCoreGetUserAppDirectoryPath() . '/' . $directoryName);
                 break;
             default:
                 return array('error' => 'Unable to find requested directory');

--- a/core/includes/SdmCore.php
+++ b/core/includes/SdmCore.php
@@ -325,17 +325,17 @@ class SdmCore {
     /**
      *  Attempts to return a directory listing for the specified directory (i.e., $directory_name)
      * @param string $directory_name <p>The name of the directory to create a listing of.</p>
-     * @param string $directory_location_reference <p>The name of a directory to be used as a starting reference point to search for the directory we want to create a listing for.
+     * @param string $directoryLocationReference <p>The name of a directory to be used as a starting reference point to search for the directory we want to create a listing for.
      * <br><br>
      * <i>$this->sdmCoreGetDirectoryListing('', 'core')</i>
      * <br><br>
-     * would return a directory listing for '<b>SITESROOTURL</b>/core/'. (Note: passing an empty string will return the name of the directory being used as a locational reference.(i.e., $directory_location_reference)
+     * would return a directory listing for '<b>SITESROOTURL</b>/core/'. (Note: passing an empty string will return the name of the directory being used as a locational reference.(i.e., $directoryLocationReference)
      * <br><br><b>(Note: there is one special value you can pass to this parameter, the 'CURRENT_THEME' value will return a directory listing for the current theme)</b>
      * </p>
      * @return array A directory listing for $directory_name as an array.
      */
-    final public function sdmCoreGetDirectoryListing($directory_name, $directory_location_reference) {
-        switch ($directory_location_reference) {
+    final public function sdmCoreGetDirectoryListing($directory_name, $directoryLocationReference) {
+        switch ($directoryLocationReference) {
             // search for directory in site root
             case 'root':
                 return scandir($this->sdmCoreGetRootDirectoryPath() . '/' . $directory_name);
@@ -416,12 +416,12 @@ class SdmCore {
         // attempt to format the array so the KEYS can be used for display, and the VALUES can be used in code | "pageName" will become "Page Name" and will be used as a key
         // Note: Pages not named with the camelCase convention may not display intuitivly...
         // @todo create a method that formats page names into camel case on page creation...
-        // intialize $available_pages array | will prevent PHP erros if no pages exist in CORE
-        $available_pages = array();
+        // intialize $availablePages array | will prevent PHP erros if no pages exist in CORE
+        $availablePages = array();
         foreach ($pages as $page) {
-            $available_pages[ucwords(preg_replace('/(?<!\ )[A-Z]/', ' $0', $page))] = $page;
+            $availablePages[ucwords(preg_replace('/(?<!\ )[A-Z]/', ' $0', $page))] = $page;
         }
-        return $available_pages;
+        return $availablePages;
     }
 
     /**
@@ -431,8 +431,8 @@ class SdmCore {
      */
     final public function sdmCoreDetermineEnabledApps() {
         $data = $this->sdmCoreGetDataObject();
-        $enabled_apps = $data->settings->enabledapps;
-        return $enabled_apps;
+        $enabledApps = $data->settings->enabledapps;
+        return $enabledApps;
     }
 
     /**

--- a/core/includes/SdmForm.php
+++ b/core/includes/SdmForm.php
@@ -32,7 +32,7 @@ class SdmForm {
      *
      */
     public function __construct() {
-        $this->form_id = (isset($this->form_id) ? $this->form_id : $this->sdmFormGenerateFormId());
+        $this->formId = (isset($this->formId) ? $this->formId : $this->sdmFormGenerateFormId());
         $this->form_elements = (isset($this->form_elements) ? $this->form_elements : array(
                     // default form element example
                     array(
@@ -195,8 +195,8 @@ class SdmForm {
      */
     public function sdmFormGenerateFormId() {
         // we only set id if it is NOT already set | checked via terenary operator (condition ? true : false)
-        $this->form_id = (!isset($this->form_id) ? rand(1000, 9999) . '-' . $this->sdmFormAlphaRand(8) : $this->form_id);
-        return $this->form_id;
+        $this->formId = (!isset($this->formId) ? rand(1000, 9999) . '-' . $this->sdmFormAlphaRand(8) : $this->formId);
+        return $this->formId;
     }
 
     /**
@@ -204,7 +204,7 @@ class SdmForm {
      * @return string Form ID as a string.
      */
     public function sdmFormGetFormId() {
-        return (isset($this->form_id) ? $this->form_id : 'FORM ID NOT SET!');
+        return (isset($this->formId) ? $this->formId : 'FORM ID NOT SET!');
     }
 
     /** sdm_alpha_rand($numChars)

--- a/core/includes/SdmForm.php
+++ b/core/includes/SdmForm.php
@@ -8,7 +8,7 @@
 class SdmForm {
 
     // properties //
-    private $form_id;
+    private $formId;
     private $form;
     public $form_handler;
     public $form_elements;
@@ -20,7 +20,7 @@ class SdmForm {
      *
      * PROPERTIES:
      *
-     * $form_id : defined internally, upon the creation of an SdmForm instance. A unique ID is assigned to this property via the internal sdmFormGenerateFormId() function
+     * $formId : defined internally, upon the creation of an SdmForm instance. A unique ID is assigned to this property via the internal sdmFormGenerateFormId() function
      *
      * $form : The assembled form.
      *
@@ -85,7 +85,7 @@ class SdmForm {
         ));
         $this->method = (isset($this->method) ? $this->method : 'post');
         $this->form_handler = (isset($this->form_handler) ? $this->form_handler : '');
-        $this->form = (isset($this->form) ? $this->form : $this->sdmFormBuildForm(str_replace('/index.php', '', 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'])));
+        $this->form = (isset($this->form) ? $this->form : $this->sdmFormBuildForm());
         $this->submitLabel = (isset($this->submitLabel) ? $this->submitLabel : 'Submit');
     }
 
@@ -95,6 +95,10 @@ class SdmForm {
      * @return The Form html
      */
     public function sdmFormBuildForm($rootUrl) {
+        if (!isset($rootUrl)) {
+            // if $rootUrl is not set, then attempt to default to site root url by guessing it
+            $rootUrl = str_replace('/index.php', '', 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF']);
+        }
         // intial form html
         $formHtml = '<!-- form "' . $this->sdmFormGetFormId() . '" --><form method="' . $this->method . '" action="' . $rootUrl . '/index.php?page=' . $this->form_handler . '">';
 

--- a/core/includes/SdmForm.php
+++ b/core/includes/SdmForm.php
@@ -96,7 +96,7 @@ class SdmForm {
      */
     public function sdmFormBuildForm($rootUrl) {
         // intial form html
-        $form_html = '<!-- form "' . $this->sdmFormGetFormId() . '" --><form method="' . $this->method . '" action="' . $rootUrl . '/index.php?page=' . $this->form_handler . '">';
+        $formHtml = '<!-- form "' . $this->sdmFormGetFormId() . '" --><form method="' . $this->method . '" action="' . $rootUrl . '/index.php?page=' . $this->form_handler . '">';
 
         // first sort elements based on element's "place"
         $element_order = array(); // used to sort items
@@ -109,43 +109,43 @@ class SdmForm {
         foreach ($this->form_elements as $key => $value) {
             switch ($value['type']) {
                 case 'text':
-                    $form_html = $form_html . '<!-- form element "SdmForm[' . $value['id'] . ']" --><label for="SdmForm[' . $value['id'] . ']">' . $value['element'] . '</label><input name="SdmForm[' . $value['id'] . ']" type="text" ' . (isset($value['value']) ? 'value="' . $value['value'] . '"' : '') . '><!-- close form element "SdmForm[' . $value['id'] . ']" -->';
+                    $formHtml = $formHtml . '<!-- form element "SdmForm[' . $value['id'] . ']" --><label for="SdmForm[' . $value['id'] . ']">' . $value['element'] . '</label><input name="SdmForm[' . $value['id'] . ']" type="text" ' . (isset($value['value']) ? 'value="' . $value['value'] . '"' : '') . '><!-- close form element "SdmForm[' . $value['id'] . ']" -->';
                     break;
                 case 'password':
-                    $form_html = $form_html . '<!-- form element "SdmForm[' . $value['id'] . ']" --><label for="SdmForm[' . $value['id'] . ']">' . $value['element'] . '</label><input name="SdmForm[' . $value['id'] . ']" type="password" ' . (isset($value['value']) ? 'value="' . $value['value'] . '"' : '') . '><!-- close form element "SdmForm[' . $value['id'] . ']" -->';
+                    $formHtml = $formHtml . '<!-- form element "SdmForm[' . $value['id'] . ']" --><label for="SdmForm[' . $value['id'] . ']">' . $value['element'] . '</label><input name="SdmForm[' . $value['id'] . ']" type="password" ' . (isset($value['value']) ? 'value="' . $value['value'] . '"' : '') . '><!-- close form element "SdmForm[' . $value['id'] . ']" -->';
                     break;
                 case 'textarea':
-                    $form_html = $form_html . '<!-- form element "SdmForm[' . $value['id'] . ']" --><label for="SdmForm[' . $value['id'] . ']">' . $value['element'] . '</label><textarea name="SdmForm[' . $value['id'] . ']">' . (isset($value['value']) ? $value['value'] : '') . '</textarea><!-- close form element "SdmForm[' . $value['id'] . ']" -->';
+                    $formHtml = $formHtml . '<!-- form element "SdmForm[' . $value['id'] . ']" --><label for="SdmForm[' . $value['id'] . ']">' . $value['element'] . '</label><textarea name="SdmForm[' . $value['id'] . ']">' . (isset($value['value']) ? $value['value'] : '') . '</textarea><!-- close form element "SdmForm[' . $value['id'] . ']" -->';
                     break;
                 case 'select':
-                    $form_html = $form_html . '<!-- form element "SdmForm[' . $value['id'] . ']" --><label for="SdmForm[' . $value['id'] . ']">' . $value['element'] . '</label><select name="SdmForm[' . $value['id'] . ']">';
+                    $formHtml = $formHtml . '<!-- form element "SdmForm[' . $value['id'] . ']" --><label for="SdmForm[' . $value['id'] . ']">' . $value['element'] . '</label><select name="SdmForm[' . $value['id'] . ']">';
                     foreach ($value['value'] as $option => $option_value) {
-                        $form_html = $form_html . '<option value="' . (substr($option_value, 0, 8) === 'default_' ? $this->sdmFormEncode(str_replace('default_', '', $option_value)) . '" selected="selected"' : $this->sdmFormEncode($option_value) . '"') . '>' . $option . '</option>';
+                        $formHtml = $formHtml . '<option value="' . (substr($option_value, 0, 8) === 'default_' ? $this->sdmFormEncode(str_replace('default_', '', $option_value)) . '" selected="selected"' : $this->sdmFormEncode($option_value) . '"') . '>' . $option . '</option>';
                     }
-                    $form_html = $form_html . '</select><!-- close form element "SdmForm[' . $value['id'] . ']" -->';
+                    $formHtml = $formHtml . '</select><!-- close form element "SdmForm[' . $value['id'] . ']" -->';
                     break;
                 case 'radio':
-                    $form_html = $form_html . '<!-- form element "SdmForm[' . $value['id'] . ']" --><p id="label-for-SdmForm[' . $value['id'] . ']">' . $value['element'] . '</p>';
+                    $formHtml = $formHtml . '<!-- form element "SdmForm[' . $value['id'] . ']" --><p id="label-for-SdmForm[' . $value['id'] . ']">' . $value['element'] . '</p>';
                     foreach ($value['value'] as $radio => $radio_value) {
-                        $form_html = $form_html . '<label  for="SdmForm[' . $value['id'] . ']">' . $radio . '</label><input type="radio" name="SdmForm[' . $value['id'] . ']" value="' . (substr($radio_value, 0, 8) === 'default_' ? $this->sdmFormEncode(str_replace('default_', '', $radio_value)) . '" checked="checked"' : $this->sdmFormEncode($radio_value) . '"') . '><!-- close form element "SdmForm[' . $value['id'] . ']" -->';
+                        $formHtml = $formHtml . '<label  for="SdmForm[' . $value['id'] . ']">' . $radio . '</label><input type="radio" name="SdmForm[' . $value['id'] . ']" value="' . (substr($radio_value, 0, 8) === 'default_' ? $this->sdmFormEncode(str_replace('default_', '', $radio_value)) . '" checked="checked"' : $this->sdmFormEncode($radio_value) . '"') . '><!-- close form element "SdmForm[' . $value['id'] . ']" -->';
                     }
                     break;
                 case 'checkbox':
-                    $form_html = $form_html . '<!-- form element "SdmForm[' . $value['id'] . ']" --><p id="label-for-SdmForm[' . $value['id'] . ']">' . $value['element'] . '</p>';
+                    $formHtml = $formHtml . '<!-- form element "SdmForm[' . $value['id'] . ']" --><p id="label-for-SdmForm[' . $value['id'] . ']">' . $value['element'] . '</p>';
                     foreach ($value['value'] as $checkbox => $checkbox_value) {
-                        $form_html = $form_html . '<label  for="SdmForm[' . $value['id'] . ']">' . $checkbox . '</label><input type="checkbox" name="SdmForm[' . $value['id'] . '][]" value="' . (substr($checkbox_value, 0, 8) === 'default_' ? $this->sdmFormEncode(str_replace('default_', '', $checkbox_value)) . '" checked="checked"' : $this->sdmFormEncode($checkbox_value) . '"') . '><!-- close form element "SdmForm[' . $value['id'] . ']" -->';
+                        $formHtml = $formHtml . '<label  for="SdmForm[' . $value['id'] . ']">' . $checkbox . '</label><input type="checkbox" name="SdmForm[' . $value['id'] . '][]" value="' . (substr($checkbox_value, 0, 8) === 'default_' ? $this->sdmFormEncode(str_replace('default_', '', $checkbox_value)) . '" checked="checked"' : $this->sdmFormEncode($checkbox_value) . '"') . '><!-- close form element "SdmForm[' . $value['id'] . ']" -->';
                     }
                     break;
                 case 'hidden':
-                    $form_html = $form_html . '<!-- form element "SdmForm[' . $value['id'] . ']" --><input name="SdmForm[' . $value['id'] . ']" type="hidden" value="' . $this->sdmFormEncode($value['value']) . '"><!-- close form element "SdmForm[' . $value['id'] . ']" -->';
+                    $formHtml = $formHtml . '<!-- form element "SdmForm[' . $value['id'] . ']" --><input name="SdmForm[' . $value['id'] . ']" type="hidden" value="' . $this->sdmFormEncode($value['value']) . '"><!-- close form element "SdmForm[' . $value['id'] . ']" -->';
                     break;
                 default:
                     break;
             }
         }
         // add hidden element to store form id
-        $form_html .= '<!-- built-in form element "form_id" --><input type="hidden" name="SdmForm[form_id]" value="' . $this->sdmFormGetFormId() . '"><!-- close built-in form element "form_id" -->';
-        $this->form = $form_html . '<input value="' . $this->submitLabel . '" type="submit"></form><!-- close form ' . $this->sdmFormGetFormId() . ' -->';
+        $formHtml .= '<!-- built-in form element "form_id" --><input type="hidden" name="SdmForm[form_id]" value="' . $this->sdmFormGetFormId() . '"><!-- close built-in form element "form_id" -->';
+        $this->form = $formHtml . '<input value="' . $this->submitLabel . '" type="submit"></form><!-- close form ' . $this->sdmFormGetFormId() . ' -->';
         return $this->form;
     }
 
@@ -203,18 +203,18 @@ class SdmForm {
         return (isset($this->form_id) ? $this->form_id : 'FORM ID NOT SET!');
     }
 
-    /** sdm_alpha_rand($num_chars)
+    /** sdm_alpha_rand($numChars)
      * Random letter generator. Used in Player and Package ID generation.
-     * @param int $num_chars Number of letters to generate.
+     * @param int $numChars Number of letters to generate.
      * There are spaces and indents are NOT generated, so letters are clumped up into one long string of characters.
      * i.e., sdm_alpha_rand(4) may generate the string 'sonv', or 'bUsw', etc...
-     * @return string Random String $num_chars in length.
+     * @return string Random String $numChars in length.
      * i.e., sdmFormAlphaRand(3) would produce a string of random alphanumeric characters 3 characters in length
      */
-    public function sdmFormAlphaRand($num_chars) {
+    public function sdmFormAlphaRand($numChars) {
         $alphabet = 'aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpPqQrRsStTuUvVwWxXyYzZ';
         $string = '';
-        for ($inc = 0; $inc <= $num_chars; $inc++) {
+        for ($inc = 0; $inc <= $numChars; $inc++) {
             $i = rand(0, 51);
             $string = $string . $alphabet[$i];
         }

--- a/core/includes/SdmForm.php
+++ b/core/includes/SdmForm.php
@@ -94,7 +94,7 @@ class SdmForm {
      * @var string $rootUrl the sites root url. Insures requests are made from site of origin.
      * @return The Form html
      */
-    public function sdmFormBuildForm($rootUrl) {
+    public function sdmFormBuildForm($rootUrl = null) {
         if (!isset($rootUrl)) {
             // if $rootUrl is not set, then attempt to default to site root url by guessing it
             $rootUrl = str_replace('/index.php', '', 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF']);

--- a/core/includes/SdmGatekeeper.php
+++ b/core/includes/SdmGatekeeper.php
@@ -42,7 +42,7 @@ class SdmGatekeeper extends SdmCore implements SessionHandlerInterface {
                 }
                 break;
             default:
-                error_log('PHP Warning: SdmGateKeeper - Invalid storage type requested for session with id ending in ' . substr(session_id(), -7) . '.');
+                error_log('PHP Warning: SdmGateKeeper - Invalid storage type requested for session "' . $sessionName . '" with id ending in ' . substr(session_id(), -7) . '.');
                 break;
         }
         return;
@@ -292,8 +292,7 @@ class SdmGatekeeper extends SdmCore implements SessionHandlerInterface {
      * @return array <p>Associative array of .gk params decoded from an array returned by loading a .gk file via file()</p>
      */
     final private static function sdmGatekeeperDecodeParams($gkfile) {
-
-        foreach ($gkfile as $param => $value) {
+        foreach ($gkfile as $value) {
             $paramName = SdmCore::sdmCoreStrSlice('->' . $value, '->', '=');
             $paramValuesString = SdmCore::sdmCoreStrSlice($value, '=', ';');
             $paramValuesArray[$paramName] = explode(',', $paramValuesString);

--- a/core/includes/SdmGatekeeper.php
+++ b/core/includes/SdmGatekeeper.php
@@ -267,12 +267,12 @@ class SdmGatekeeper extends SdmCore implements SessionHandlerInterface {
      * file or false if no .gk file is exists.
      */
     final public static function sdmGatekeeperReadAppGkParams($app) {
-        $SdmCore = new SdmCore();
-        if (file_exists($SdmCore->sdmCoreGetCoreAppDirectoryPath() . '/' . $app . '/' . $app . '.gk')) {
-            $gkfile = file($SdmCore->sdmCoreGetCoreAppDirectoryPath() . '/' . $app . '/' . $app . '.gk');
+        $gkSdmCore = new SdmCore();
+        if (file_exists($gkSdmCore->sdmCoreGetCoreAppDirectoryPath() . '/' . $app . '/' . $app . '.gk')) {
+            $gkfile = file($gkSdmCore->sdmCoreGetCoreAppDirectoryPath() . '/' . $app . '/' . $app . '.gk');
             $params = SdmGatekeeper::sdmGatekeeperDecodeParams($gkfile);
-        } else if (file_exists($SdmCore->sdmCoreGetUserAppDirectoryPath() . '/' . $app . '/' . $app . '.gk')) {
-            $gkfile = file($SdmCore->sdmCoreGetUserAppDirectoryPath() . '/' . $app . '/' . $app . '.gk');
+        } else if (file_exists($gkSdmCore->sdmCoreGetUserAppDirectoryPath() . '/' . $app . '/' . $app . '.gk')) {
+            $gkfile = file($gkSdmCore->sdmCoreGetUserAppDirectoryPath() . '/' . $app . '/' . $app . '.gk');
             $params = SdmGatekeeper::sdmGatekeeperDecodeParams($gkfile);
         } else {
             $params = false;

--- a/core/includes/SdmNms.php
+++ b/core/includes/SdmNms.php
@@ -116,15 +116,6 @@ class SdmMenu extends SdmMenuItem {
  */
 class SdmNms extends SdmCore {
 
-    private static $Initialized;
-
-    public static function sdmNmsInitializeNms() {
-        if (!isset(self::$Initialized)) {
-            self::$Initialized = new SdmNms;
-        }
-        return self::$Initialized;
-    }
-
     /**
      * Add a menu to our site.
      * @param mixed $menu <p>The new menu. It is preferable to pass in an SdmMenu object,

--- a/index.php
+++ b/index.php
@@ -7,7 +7,7 @@ require(__DIR__ . '/core/config/startup.php');
 echo $sdmassembler->sdmAssemblerAssembleHtmlHeader();
 
 // load our theme and build the page
-include($sdmcore->sdmCoreGetCurrentThemeDirectoryPath() . '/page.php');
+include($sdmassembler->sdmCoreGetCurrentThemeDirectoryPath() . '/page.php');
 
 // assemlbe the required closing html tags/data
 echo $sdmassembler->sdmAssemblerAssembleHtmlRequiredClosingTags();

--- a/themes/sdm/page.php
+++ b/themes/sdm/page.php
@@ -1,7 +1,7 @@
 <div id="lockedwrapper">
     <div id='main_content'>
         <?php
-        echo SdmAssembler::sdmAssemblerGetContentHtml('main_content', $sdmassembler_themeContentObject);
+        echo SdmAssembler::sdmAssemblerGetContentHtml('main_content', $sdmAssemblerThemeContentObject);
         ?>
     </div>
 </div>

--- a/themes/sdm2/page.php
+++ b/themes/sdm2/page.php
@@ -1,7 +1,7 @@
 <div id="lockedwrapper">
     <div id='main_content'>
         <?php
-        echo SdmAssembler::sdmAssemblerGetContentHtml('main_content', $sdmassembler_themeContentObject);
+        echo SdmAssembler::sdmAssemblerGetContentHtml('main_content', $sdmAssemblerThemeContentObject);
         ?>
     </div>
 </div>

--- a/themes/sdmResponsive/css/style-classes.css
+++ b/themes/sdmResponsive/css/style-classes.css
@@ -31,7 +31,7 @@ body {
     border-bottom-color:#ffffff;
     border-left-color:#000000;
     border-width:5px;
-    border-radius:0px;
+    border-radius:0;
     border-style:none none double none;
 }
 

--- a/themes/sdmResponsive/css/style-classes.css
+++ b/themes/sdmResponsive/css/style-classes.css
@@ -7,6 +7,7 @@
 */
 
 body {
+    background: -webkit-gradient(bottom right, black, #55eeff, black); /* For Chrome and Safari4+ */
     background: -webkit-linear-gradient(left top, black , #55eeff, black); /* For Safari 5.1 to 6.0 */
     background: -o-linear-gradient(bottom right, black , #55eeff, black); /* For Opera 11.1 to 12.0 */
     background: -moz-linear-gradient(bottom right, black , #55eeff, black); /* For Firefox 3.6 to 15 */

--- a/themes/sdmResponsive/page.php
+++ b/themes/sdmResponsive/page.php
@@ -2,27 +2,27 @@
 <div class="row row-min-wid-fix">
     <div id="top-menu"class="col-12 col-m-12 border-bottom">
         <?php
-        echo SdmAssembler::sdmAssemblerGetContentHtml('top-menu', $sdmassembler_themeContentObject);
+        echo SdmAssembler::sdmAssemblerGetContentHtml('top-menu', $sdmAssemblerThemeContentObject);
         ?>
     </div>
 </div>
 <!-- row 2 -->
 <div class="row row-min-wid-fix padded-row">
     <?php
-    $sidebar = SdmAssembler::sdmAssemblerGetContentHtml('side-menu', $sdmassembler_themeContentObject);
+    $sidebar = SdmAssembler::sdmAssemblerGetContentHtml('side-menu', $sdmAssemblerThemeContentObject);
     $sidebarInvalidValues = array(null, '', '<!-- side-menu placeholder -->');
     $sideBarExists = (in_array($sidebar, $sidebarInvalidValues) === true ? false : true);
     if ($sideBarExists === true) {
         ?>
         <div id="side-menu" class="col-3 col-m-3 rounded">
             <?php
-            echo SdmAssembler::sdmAssemblerGetContentHtml('side-menu', $sdmassembler_themeContentObject);
+            echo SdmAssembler::sdmAssemblerGetContentHtml('side-menu', $sdmAssemblerThemeContentObject);
             ?>    </div>
         <div id="locked-spacer" class="col-1 col-m-1 spacer"></div>
     <?php } ?>
     <div id="main_content"class="<?php echo ($sideBarExists === true ? 'col-8 col-m-8' : 'col-12 col-m-12'); ?> rounded">
         <?php
-        echo SdmAssembler::sdmAssemblerGetContentHtml('main_content', $sdmassembler_themeContentObject);
+        echo SdmAssembler::sdmAssemblerGetContentHtml('main_content', $sdmAssemblerThemeContentObject);
         ?>
     </div>
 </div>
@@ -30,7 +30,7 @@
 <div class="row row-min-wid-fix">
     <div id="footer"class="col-12 col-m-12">
         <?php
-        echo SdmAssembler::sdmAssemblerGetContentHtml('footer', $sdmassembler_themeContentObject);
+        echo SdmAssembler::sdmAssemblerGetContentHtml('footer', $sdmAssemblerThemeContentObject);
         ?>
     </div>
 </div>

--- a/themes/sdmSimple/page.php
+++ b/themes/sdmSimple/page.php
@@ -1,5 +1,5 @@
 <div id="main_content">
     <?php
-    echo SdmAssembler::sdmAssemblerGetContentHtml('main_content', $sdmassembler_themeContentObject);
+    echo SdmAssembler::sdmAssemblerGetContentHtml('main_content', $sdmAssemblerThemeContentObject);
     ?>
 </div>


### PR DESCRIPTION
SdmForm(): sdmFormBuildForm() $rootUrl parameter no defaults to null allowing devs to exclude it. If $rootUrl is not set then it will be set internally by the sdmFormBuildForm() method; SdmCoreOverview core app: Changed how core overview outputs its content. Instantiating SdmCore from within co.php was causing SdmCore() to provide corrupted paths which made it unusable. co.php has been removed; SdmCore(): sdmCoreLoadDataObject() is working again. Now only the requested page is stored in DataObject->content unless the $requestedPageOnly parameter is set to FALSE, in which case all pages will be stored in DataObject->content. This will hopefully help performance so the Sdm Cms does not have to pass around huge DataObjects for site with lots of content.