### PR TITLE
Sdmcms cleanup

### DIFF
--- a/apps/SdmContentGenerator/SdmContentGenerator.php
+++ b/apps/SdmContentGenerator/SdmContentGenerator.php
@@ -98,4 +98,4 @@ if ($sdmassembler->sdmCoreDetermineRequestedPage() === 'SdmContentGenerator') {
     }
     $output .= '</ul>';
 }
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($output, $options);

--- a/apps/SdmDevMenu/SdmDevMenu.php
+++ b/apps/SdmDevMenu/SdmDevMenu.php
@@ -1,7 +1,7 @@
 <?php
 
 // app description page | if you visit YOURSITE.com/index.php?page=SdmDevMenu this output will be dsiplayed
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h2>DEV MENU</h2><p>The SDM DEV MENU app outputs a menu that has links to all pages available in core, and any page that matches the name of an enabled app. For now the meni itself is restricted to the user role "root", and the SdmDevMenu app page is not restricted at all. This is for testing the new role checking being done before loading our apps.</p>', array('wrapper' => 'main_content', 'incmethod' => 'overwrite', 'incpages' => array('SdmDevMenu')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<h2>DEV MENU</h2><p>The SDM DEV MENU app outputs a menu that has links to all pages available in core, and any page that matches the name of an enabled app. For now the meni itself is restricted to the user role "root", and the SdmDevMenu app page is not restricted at all. This is for testing the new role checking being done before loading our apps.</p>', array('wrapper' => 'main_content', 'incmethod' => 'overwrite', 'incpages' => array('SdmDevMenu')));
 // add a dev menu to all pages that includes links to all pages and enabled apps
 $pages = $sdmassembler->sdmCoreDetermineAvailablePages();
 // Possibly incorporate the following few lines that put together a list of available apps and pages into one array into the sdmCoreDetermineAvailablePages() method
@@ -13,4 +13,4 @@ foreach ($availablePages as $link) {
 }
 $devMenu .= '</ul></div><!-- End Dev Menu -->';
 // incorporate devmenu
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $devMenu, array('wrapper' => 'side-menu', 'incmethod' => 'append', 'incpages' => $availablePages, 'roles' => array('root')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($devMenu, array('wrapper' => 'side-menu', 'incmethod' => 'append', 'incpages' => $availablePages, 'roles' => array('root')));

--- a/apps/SdmDevOutput/SdmDevOutput.php
+++ b/apps/SdmDevOutput/SdmDevOutput.php
@@ -1,4 +1,4 @@
 <?php
 
 $output = '<!-- Sdm Dev Output App Placeholder -->';
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($output);

--- a/apps/gitTools/gitTools.php
+++ b/apps/gitTools/gitTools.php
@@ -15,6 +15,6 @@ $branchname = $explodedstring[2]; //get the one that is always the branch name
 
 $output = "<div style='clear:both;color: #66CCCC; background: #000000; border-radius: 9px; padding: 10px; margin: 0px 0px 20px 0px; text-align: center;'>Current GIT branch: <i style='color: #00CC33; text-transform: uppercase;'>" . $branchname . "</i></div>";
 
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, array('incmethod' => 'prepend'));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($output, array('incmethod' => 'prepend'));
 
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>Git Tools</h3><p>This app provides tools for working with git. At the moment the only tool is a <i>branch viewer</i> that show the current git branch at the top of the main_content menu wrapper on every page.</p><p>Further development of this app will occur in the future, and this app will have a variety of tools for using git with your SDM CMS site.</p>', array('incpages' => array('gitTools'), 'incmethod' => 'append'));
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<h3>Git Tools</h3><p>This app provides tools for working with git. At the moment the only tool is a <i>branch viewer</i> that show the current git branch at the top of the main_content menu wrapper on every page.</p><p>Further development of this app will occur in the future, and this app will have a variety of tools for using git with your SDM CMS site.</p>', array('incpages' => array('gitTools'), 'incmethod' => 'append'));

--- a/apps/helloWorld/helloWorld.php
+++ b/apps/helloWorld/helloWorld.php
@@ -13,4 +13,4 @@ $options = array(
 ); // options array determines how an apps output is incorporated into the page
 $devmode = false; // if set to true then dev data about the app output will be displayed on the page as well
 // we use the Sdm Assembler's sdmAssemblerIncorporateAppOutput() method to display our apps output on the page
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, $options, $devmode);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($output, $options, $devmode);

--- a/core/apps/SdmAuth/SdmAuth.php
+++ b/core/apps/SdmAuth/SdmAuth.php
@@ -13,6 +13,6 @@ switch ($sdmassembler->SdmCoreDetermineRequestedPage()) {
         break;
 
     default:
-        $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<!-- SdmAuth Login Form -->' . 'The login form could not be loaded at this time. Please try again later.<br />-- Page Req : ' . $sdmassembler->SdmCoreDetermineRequestedPage() . '<!-- End SdmAuth Login Form -->', $options);
+        $sdmassembler->sdmAssemblerIncorporateAppOutput('<!-- SdmAuth Login Form -->' . 'The login form could not be loaded at this time. Please try again later.<br />-- Page Req : ' . $sdmassembler->SdmCoreDetermineRequestedPage() . '<!-- End SdmAuth Login Form -->', $options);
         break;
 }

--- a/core/apps/SdmAuth/forms/loginForm.php
+++ b/core/apps/SdmAuth/forms/loginForm.php
@@ -3,7 +3,7 @@
 $loginGateKeeper = new SdmGatekeeper();
 // check encrypted LAST_ACTIVITY against $_SESSION['auth_cleared'], if they don't match then user is NOT logged in
 if (SdmGatekeeper::sdmGatekeeperAuthenticate() === true) {
-    $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<!-- SdmAuth Login Form -->' . '<p>Your are currently logged in.</p><p>' . '<span style="font-size:.6em;"><a href="' . $sdmassembler->SdmCoreGetRootDirectoryUrl() . '/index.php?page=SdmAuthLogin&logout=' . session_id() . '">Logout</a></span></p>' . '<!-- End SdmAuth Login Form -->', $options);
+    $sdmassembler->sdmAssemblerIncorporateAppOutput('<!-- SdmAuth Login Form -->' . '<p>Your are currently logged in.</p><p>' . '<span style="font-size:.6em;"><a href="' . $sdmassembler->SdmCoreGetRootDirectoryUrl() . '/index.php?page=SdmAuthLogin&logout=' . session_id() . '">Logout</a></span></p>' . '<!-- End SdmAuth Login Form -->', $options);
 } else {
     // Build and display the Login form.
     $loginForm = new SdmForm();
@@ -34,5 +34,5 @@ if (SdmGatekeeper::sdmGatekeeperAuthenticate() === true) {
         ),
     );
     $loginForm->sdmFormBuildForm($sdmassembler->SdmCoreGetRootDirectoryUrl());
-    $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<!-- SdmAuth Login Form -->' . $loginForm->sdmFormGetForm() . '<!-- End SdmAuth Login Form -->', $options);
+    $sdmassembler->sdmAssemblerIncorporateAppOutput('<!-- SdmAuth Login Form -->' . $loginForm->sdmFormGetForm() . '<!-- End SdmAuth Login Form -->', $options);
 }

--- a/core/apps/SdmAuth/handlers/SdmAuthLogin.php
+++ b/core/apps/SdmAuth/handlers/SdmAuthLogin.php
@@ -10,16 +10,16 @@ switch (isset($_GET['logout'])) {
     case 'logout':
         session_unset();
         session_destroy();
-        $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Your have been logged out successfully.</p>', $options);
+        $sdmassembler->sdmAssemblerIncorporateAppOutput('<p>Your have been logged out successfully.</p>', $options);
         break;
     default:
         // check if login credentials were valid | if they were login user, if not then display login form and a message indicating the login credentials were not valid.
         if ($handler->sdmFormGetSubmittedFormValue('username') === $devUser && $handler->sdmFormGetSubmittedFormValue('password') === $devPass) {
             $_SESSION['sdmauth'] = 'auth';
             $_SESSION['userRole'] = $devUserRole;
-            $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Your are logged in.</p>', $options);
+            $sdmassembler->sdmAssemblerIncorporateAppOutput('<p>Your are logged in.</p>', $options);
         } else {
-            $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Invalid Login Credentials</p>', $options);
+            $sdmassembler->sdmAssemblerIncorporateAppOutput('<p>Invalid Login Credentials</p>', $options);
             require_once($sdmassembler->SdmCoreGetCoreAppDirectoryPath() . '/SdmAuth/forms/loginForm.php');
         }
         break;

--- a/core/apps/SdmCoreOverview/SdmCoreOverview.php
+++ b/core/apps/SdmCoreOverview/SdmCoreOverview.php
@@ -12,4 +12,4 @@ if ($sdmassembler->sdmCoreDetermineRequestedPage() === 'SdmCoreOverview') {
     $output .= ob_get_clean();
 }
 // incorporate core overview
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($output, $options);

--- a/core/apps/SdmCoreOverview/SdmCoreOverview.php
+++ b/core/apps/SdmCoreOverview/SdmCoreOverview.php
@@ -3,12 +3,12 @@
 // options
 $options = array('wrapper' => 'main_content', 'incmethod' => 'append', 'incpages' => array('SdmCoreOverview'));
 // output
-$output = '<h2>Overview of current state the CORE</h2><p>The SDM Core Overview app displays the current state of the SDM CORE.</p>';
+$output = '<h2>Overview of current state the CORE</h2><p>The SDM Core Overview app displays the current state of the Core Data Object stored in data.json</p>';
 // load the core overview file
-$dataObject = $sdmassembler->sdmCoreGetDataObject();
+$dataObject = $sdmassembler->sdmCoreLoadDataObject(false);
 if ($sdmassembler->sdmCoreDetermineRequestedPage() === 'SdmCoreOverview') {
     ob_start();
-    var_dump($dataObject);
+    $sdmassembler->sdmCoreSdmReadArray($dataObject);
     $output .= ob_get_clean();
 }
 // incorporate core overview

--- a/core/apps/SdmErrorLog/SdmErrorLog.php
+++ b/core/apps/SdmErrorLog/SdmErrorLog.php
@@ -1,13 +1,13 @@
 <?php
 
 // app description page | if you visit YOURSITE.com/index.php?page=SdmDevMenu this output will be dsiplayed
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h2>Site Errors</h2><p>The SDM Error Log app displays the sites error log and color codes the errors as follows:</p><p style="border:1px solid; border-radius: 20px; color:#DD0000;padding:20px;background:#303030">Fatal</p><p style="border:1px solid; border-radius: 20px; color:#FDD017;padding:20px;background:#000000">Warning</p><p style="border:1px solid; border-radius: 20px; color:#6C7DCC;padding:20px;background:#303030">Notice</p><p style="border:1px solid; border-radius: 20px; color:#FFFFFF;padding:20px;background:#000000">Other</p>', array('wrapper' => 'main_content', 'incmethod' => 'append', 'incpages' => array('SdmErrorLog')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<h2>Site Errors</h2><p>The SDM Error Log app displays the sites error log and color codes the errors as follows:</p><p style="border:1px solid; border-radius: 20px; color:#DD0000;padding:20px;background:#303030">Fatal</p><p style="border:1px solid; border-radius: 20px; color:#FDD017;padding:20px;background:#000000">Warning</p><p style="border:1px solid; border-radius: 20px; color:#6C7DCC;padding:20px;background:#303030">Notice</p><p style="border:1px solid; border-radius: 20px; color:#FFFFFF;padding:20px;background:#000000">Other</p>', array('wrapper' => 'main_content', 'incmethod' => 'append', 'incpages' => array('SdmErrorLog')));
 // get the error log with file() so we have each line as an array item. gives us some formating flexablitly later on
 $loaded_error_log = file($sdmassembler->sdmCoreGetCoreDirectoryUrl() . '/logs/sdm_core_errors.log', FILE_IGNORE_NEW_LINES || FILE_SKIP_EMPTY_LINES);
 // reverse the order of the elements because we want the newest errors to be at the top of the list
 $error_log = array_reverse($loaded_error_log);
 // display number of errors
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Number of logged errors : ' . count($error_log) . '</p>', array('incpages' => array('SdmErrorLog')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<p>Number of logged errors : ' . count($error_log) . '</p>', array('incpages' => array('SdmErrorLog')));
 $output = '';
 foreach ($error_log as $error_number => $error_message) {
     $notice_color = '#6C7DCC';
@@ -21,7 +21,7 @@ foreach ($error_log as $error_number => $error_message) {
 $output .= ($output === '' ? '<p style="color:lightgreen;border:1px solid; border-radius: 20px; padding:20px;background:black;">No errors to report.</p>' : '');
 
 // incorporate devmenu
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, array('wrapper' => 'main_content', 'incmethod' => 'append', 'incpages' => array('SdmErrorLog')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($output, array('wrapper' => 'main_content', 'incmethod' => 'append', 'incpages' => array('SdmErrorLog')));
 
 // clear error form
 $clearErrorsForm = new SdmForm();
@@ -41,12 +41,12 @@ $clearErrorsForm->submitLabel = 'Clear Error Log';
 // build the form
 $clearErrorsForm->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
 // incorporate clear errors form
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $clearErrorsForm->sdmFormGetForm(), array('wrapper' => 'main_content', 'incmethod' => 'append', 'incpages' => array('SdmErrorLog')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($clearErrorsForm->sdmFormGetForm(), array('wrapper' => 'main_content', 'incmethod' => 'append', 'incpages' => array('SdmErrorLog')));
 if (isset($_POST['SdmForm']) && isset($_POST['SdmForm']['clear_error_log' . $_POST['SdmForm']['form_id']]) && $_POST['SdmForm']['clear_error_log' . $_POST['SdmForm']['form_id']] !== 'clear_error_log' . $clearErrorsForm->sdmFormGetFormId()) {
     //$sdmassembler->sdmCoreSdmReadArray($_POST);
     if (file_put_contents($sdmassembler->sdmCoreGetCoreDirectoryPath() . '/logs/sdm_core_errors.log', trim('')) !== false) {
         $randInt = rand(1000, 9999);
-        $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '
+        $sdmassembler->sdmAssemblerIncorporateAppOutput('
             <!-- this js reloads the page once after the clear error log form is submitted so that the Sdm Error Log page reflects the change. If we did not reload then the old error log could still be shown until the page is reloaded manually | there is still a chance this data may persist for one page load -->
             <script>
               if (sessionStorage.getItem(\'errorLogClearDisplayBugFix\') !== \'fixed\') {

--- a/core/apps/contentManager/contentManager.php
+++ b/core/apps/contentManager/contentManager.php
@@ -65,7 +65,7 @@ if (substr($sdmassembler->sdmCoreDetermineRequestedPage(), 0, 14) === 'contentMa
             break;
         default:
             // present content manager menu
-            $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '
+            $sdmassembler->sdmAssemblerIncorporateAppOutput('
                 <div id="contentManager">
                 <p>Welcome to the Content Manager. Here you can create, edit, delete, and restore content</p>
                     <ul>

--- a/core/apps/contentManager/forms/contentManagerAddContentForm.php
+++ b/core/apps/contentManager/forms/contentManagerAddContentForm.php
@@ -42,4 +42,4 @@ foreach ($sdmcms->sdmCmsDetermineAvailableWrappers() as $displayValue => $machin
 }
 $editcontentform->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
 // add form to content
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);

--- a/core/apps/contentManager/forms/contentManagerAdministerAppsForm.php
+++ b/core/apps/contentManager/forms/contentManagerAdministerAppsForm.php
@@ -44,4 +44,4 @@ foreach ($available_apps as $displayValue => $machineValue) {
 
 $editcontentform->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
 // add form to content
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);

--- a/core/apps/contentManager/forms/contentManagerEditContentForm.php
+++ b/core/apps/contentManager/forms/contentManagerEditContentForm.php
@@ -61,4 +61,4 @@ foreach ($sdmcms->sdmCmsDetermineAvailableWrappers() as $displayValue => $machin
 
 $editcontentform->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
 // add form to content
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<!-- contentManager Edit Content Form --><p><i>You are currently editing the <b>' . ucwords($pagetoedit) . '</b></i></p>' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<!-- contentManager Edit Content Form --><p><i>You are currently editing the <b>' . ucwords($pagetoedit) . '</b></i></p>' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);

--- a/core/apps/contentManager/forms/contentManagerEditContentForm.php
+++ b/core/apps/contentManager/forms/contentManagerEditContentForm.php
@@ -29,7 +29,7 @@ $i = 2;
 // array of available pages
 $available_pages = $sdmassembler->sdmCoreDetermineAvailablePages();
 // load in existing content to populate form fields
-$existing_content = $sdmassembler->sdmCoreGetDataObject()->content->$pagetoedit;
+$existing_content = $sdmassembler->sdmCoreLoadDataObject(false)->content->$pagetoedit;
 // create form elements for appropriate wrappers | i.e., page specific wrappers will only be shown if $pagetoedit matches exists in the wrappers name
 foreach ($sdmcms->sdmCmsDetermineAvailableWrappers() as $displayValue => $machineValue) {
     // create place holder string if any wrappers that do not exist in core

--- a/core/apps/contentManager/forms/contentManagerSelectPageToDeleteForm.php
+++ b/core/apps/contentManager/forms/contentManagerSelectPageToDeleteForm.php
@@ -30,4 +30,4 @@ $editcontentform->form_elements = array(
 
 $editcontentform->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
 // add form to content
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);

--- a/core/apps/contentManager/forms/contentManagerSelectPageToEditForm.php
+++ b/core/apps/contentManager/forms/contentManagerSelectPageToEditForm.php
@@ -30,4 +30,4 @@ $editcontentform->form_elements = array(
 
 $editcontentform->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
 // add form to content
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);

--- a/core/apps/contentManager/forms/contentManagerSelectThemeForm.php
+++ b/core/apps/contentManager/forms/contentManagerSelectThemeForm.php
@@ -36,4 +36,4 @@ $editcontentform->form_elements = array(
 
 $editcontentform->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
 // add form to content
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<!-- contentManager Edit Content Form -->' . $editcontentform->sdmFormGetForm() . '<!-- End contentManager Edit Content Form -->', $options);

--- a/core/apps/contentManager/handlers/contentManagerAdministerAppsFormSubmission.php
+++ b/core/apps/contentManager/handlers/contentManagerAdministerAppsFormSubmission.php
@@ -42,4 +42,4 @@ else {
                 ';
 }
 
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($output, $options);

--- a/core/apps/contentManager/handlers/contentManagerDeletePageSubmission.php
+++ b/core/apps/contentManager/handlers/contentManagerDeletePageSubmission.php
@@ -27,4 +27,4 @@ else {
                 ';
 }
 
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($output, $options);

--- a/core/apps/contentManager/handlers/contentManagerSelectThemeFormSubmission.php
+++ b/core/apps/contentManager/handlers/contentManagerSelectThemeFormSubmission.php
@@ -25,4 +25,4 @@ else {
                 ';
 }
 
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($output, $options);

--- a/core/apps/contentManager/handlers/contentManagerUpdateContentFormSubmission.php
+++ b/core/apps/contentManager/handlers/contentManagerUpdateContentFormSubmission.php
@@ -36,4 +36,4 @@ if ($sdmForm->sdmFormGetSubmittedFormValue('page') !== 'contentManager') {
 } else {
     $output = '<p>Page could not be created because pages cannot use the name "contentManager" for security reasons. You can however add a page for one of the content managers stages.</p>';
 }
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output, $options);
+$sdmassembler->sdmAssemblerIncorporateAppOutput($output, $options);

--- a/core/apps/navigationManager/navigationManager.php
+++ b/core/apps/navigationManager/navigationManager.php
@@ -96,7 +96,7 @@ if (substr($sdmassembler->sdmCoreDetermineRequestedPage(), 0, 17) === 'navigatio
             break;
         default:
             // present content manager menu
-            $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '
+            $sdmassembler->sdmAssemblerIncorporateAppOutput('
                 <div id="navigationManager">
                 <p>Welcome to the Navigation Manager. Here you can create, edit, delete, and restore menus</p>
                     <ul>

--- a/core/apps/navigationManager/stages/addmenustage1.php
+++ b/core/apps/navigationManager/stages/addmenustage1.php
@@ -26,4 +26,4 @@ $addMenuFormStage1->form_elements = array(
     ),
 );
 $addMenuFormStage1->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>How many menu items will this menu have?</h3>' . $addMenuFormStage1->sdmFormGetForm(), array('incpages' => array('navigationManagerAddMenuStage1')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<h3>How many menu items will this menu have?</h3>' . $addMenuFormStage1->sdmFormGetForm(), array('incpages' => array('navigationManagerAddMenuStage1')));

--- a/core/apps/navigationManager/stages/addmenustage2.php
+++ b/core/apps/navigationManager/stages/addmenustage2.php
@@ -141,7 +141,7 @@ switch (SdmForm::sdmFormGetSubmittedFormValue('menuItem') !== null) {
             // add the last submitted menu item to our menu items array
             array_push($addMenuFormStage2->form_elements, $mi);
             // display of preview of the menu so far
-            $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<div style="border:2px solid #777777;border-radius:9px;padding:20px;height:120px;overflow:auto;"><h3>Last Submitted Menu Item:</h3><p>Display Name: <span style="color:blue;">' . SdmForm::sdmFormGetSubmittedFormValue('menuItemDisplayName') . '</span> | Destination Type : <span style="color:blue;">' . $lastSubmittedMenuItem->destinationType . '</span> | Destination: <span style="color:blue;">' . $lastSubmittedMenuItem->destination . '</span></p><h3>Menu Preview:</h3>' . $sdmnms->sdmNmsBuildMenuItemsHtml($menuItems) . '</div>', array('incmethod' => 'prepend', 'incpages' => $options['incpages']));
+            $sdmassembler->sdmAssemblerIncorporateAppOutput('<div style="border:2px solid #777777;border-radius:9px;padding:20px;height:120px;overflow:auto;"><h3>Last Submitted Menu Item:</h3><p>Display Name: <span style="color:blue;">' . SdmForm::sdmFormGetSubmittedFormValue('menuItemDisplayName') . '</span> | Destination Type : <span style="color:blue;">' . $lastSubmittedMenuItem->destinationType . '</span> | Destination: <span style="color:blue;">' . $lastSubmittedMenuItem->destination . '</span></p><h3>Menu Preview:</h3>' . $sdmnms->sdmNmsBuildMenuItemsHtml($menuItems) . '</div>', array('incmethod' => 'prepend', 'incpages' => $options['incpages']));
         } else {
             $menuItems = array();
             $mi = array(
@@ -154,10 +154,10 @@ switch (SdmForm::sdmFormGetSubmittedFormValue('menuItem') !== null) {
             array_push($addMenuFormStage2->form_elements, $mi);
         }
         $addMenuFormStage2->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
-        $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>Configure Menu Items</h3>' . $addMenuFormStage2->sdmFormGetForm(), array('incpages' => array('navigationManagerAddMenuStage2')));
+        $sdmassembler->sdmAssemblerIncorporateAppOutput('<h3>Configure Menu Items</h3>' . $addMenuFormStage2->sdmFormGetForm(), array('incpages' => array('navigationManagerAddMenuStage2')));
         break;
 
     default:
-        $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>An error occured and the form could not be submitted. Please report this to the site admin. <a href="' . $sdmassembler->sdmCoreGetRootDirectoryUrl() . '/index.php?page=homepage">Return to the Homepage</a></p>', array('incpages' => array('navigationManagerAddMenuStage2')));
+        $sdmassembler->sdmAssemblerIncorporateAppOutput('<p>An error occured and the form could not be submitted. Please report this to the site admin. <a href="' . $sdmassembler->sdmCoreGetRootDirectoryUrl() . '/index.php?page=homepage">Return to the Homepage</a></p>', array('incpages' => array('navigationManagerAddMenuStage2')));
         break;
 }

--- a/core/apps/navigationManager/stages/addmenustage3.php
+++ b/core/apps/navigationManager/stages/addmenustage3.php
@@ -24,7 +24,7 @@ $finalSubmittedMenuItem->menuItemWrappingTagType = SdmForm::sdmFormGetSubmittedF
 // add the last submitted menu item to our menu items array
 $menuItems[$finalSubmittedMenuItem->menuItemId] = $finalSubmittedMenuItem;
 // display of preview of the menu so far
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<div style="border:2px solid #777777;border-radius:9px;padding:20px;height:120px;overflow:auto;"><h3>Last Submitted Menu Item:</h3><p>Display Name: <span style="color:blue;">' . SdmForm::sdmFormGetSubmittedFormValue('menuItemDisplayName') . '</span> | Destination Type : <span style="color:blue;">' . $finalSubmittedMenuItem->destinationType . '</span> | Destination: <span style="color:blue;">' . $finalSubmittedMenuItem->destination . '</span></p><h3>Menu Preview:</h3>' . $sdmnms->sdmNmsBuildMenuItemsHtml($menuItems) . '</div>', array('incmethod' => 'prepend', 'incpages' => $options['incpages']));
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<div style="border:2px solid #777777;border-radius:9px;padding:20px;height:120px;overflow:auto;"><h3>Last Submitted Menu Item:</h3><p>Display Name: <span style="color:blue;">' . SdmForm::sdmFormGetSubmittedFormValue('menuItemDisplayName') . '</span> | Destination Type : <span style="color:blue;">' . $finalSubmittedMenuItem->destinationType . '</span> | Destination: <span style="color:blue;">' . $finalSubmittedMenuItem->destination . '</span></p><h3>Menu Preview:</h3>' . $sdmnms->sdmNmsBuildMenuItemsHtml($menuItems) . '</div>', array('incmethod' => 'prepend', 'incpages' => $options['incpages']));
 $addMenuFormStage3 = new SdmForm();
 $addMenuFormStage3->form_handler = 'navigationManagerAddMenuStage4';
 $addMenuFormStage3->form_method = 'post';
@@ -102,5 +102,5 @@ $addMenuFormStage3->form_elements = array(
     ),
 );
 $addMenuFormStage3->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $addMenuFormStage3->sdmFormGetForm(), array('incpages' => array('navigationManagerAddMenuStage3')));
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>Configure Menu</h3>', array('incmethod' => 'prepend', 'incpages' => array('navigationManagerAddMenuStage3')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($addMenuFormStage3->sdmFormGetForm(), array('incpages' => array('navigationManagerAddMenuStage3')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<h3>Configure Menu</h3>', array('incmethod' => 'prepend', 'incpages' => array('navigationManagerAddMenuStage3')));

--- a/core/apps/navigationManager/stages/addmenustage4.php
+++ b/core/apps/navigationManager/stages/addmenustage4.php
@@ -13,5 +13,5 @@ $menu->menuPlacement = SdmForm::sdmFormGetSubmittedFormValue('menuPlacement'); /
 $menu->menuWrappingTagType = SdmForm::sdmFormGetSubmittedFormValue('menuWrappingTagType'); //
 $menu->wrapper = SdmForm::sdmFormGetSubmittedFormValue('wrapper'); //
 $sdmnms->sdmNmsAddMenu($menu);
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Menu Added Successfully (Still in Dev, Does not necessarily indicate succsessful menu add yet)</p>', array('incpages' => array('navigationManagerAddMenuStage4')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<p>Menu Added Successfully (Still in Dev, Does not necessarily indicate succsessful menu add yet)</p>', array('incpages' => array('navigationManagerAddMenuStage4')));
 

--- a/core/apps/navigationManager/stages/deletemenustage1.php
+++ b/core/apps/navigationManager/stages/deletemenustage1.php
@@ -17,7 +17,7 @@ if (!empty($availableMenus) === true) {
     $deleteMenuFormStage1->submitLabel = 'Delete Menu';
     $deleteMenuFormStage1->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
 
-    $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>Delete Menu</h3>' . $deleteMenuFormStage1->sdmFormGetForm(), array('incpages' => array('navigationManagerDeleteMenuStage1')));
+    $sdmassembler->sdmAssemblerIncorporateAppOutput('<h3>Delete Menu</h3>' . $deleteMenuFormStage1->sdmFormGetForm(), array('incpages' => array('navigationManagerDeleteMenuStage1')));
 } else {
-    $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>Delete Menu</h3><p>There are no menus to delete.</p>', array('incpages' => array('navigationManagerDeleteMenuStage1')));
+    $sdmassembler->sdmAssemblerIncorporateAppOutput('<h3>Delete Menu</h3><p>There are no menus to delete.</p>', array('incpages' => array('navigationManagerDeleteMenuStage1')));
 }

--- a/core/apps/navigationManager/stages/deletemenustage2.php
+++ b/core/apps/navigationManager/stages/deletemenustage2.php
@@ -1,4 +1,4 @@
 <?php
 
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>Deleted Menu:</h3>' . $sdmnms->sdmNmsDeleteMenu(SdmForm::sdmFormGetSubmittedFormValue('menuId')), array('incpages' => array('navigationManagerDeleteMenuStage2')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<h3>Deleted Menu:</h3>' . $sdmnms->sdmNmsDeleteMenu(SdmForm::sdmFormGetSubmittedFormValue('menuId')), array('incpages' => array('navigationManagerDeleteMenuStage2')));
 ?>

--- a/core/apps/navigationManager/stages/editmenustage1.php
+++ b/core/apps/navigationManager/stages/editmenustage1.php
@@ -16,7 +16,7 @@ if (!empty($availableMenus) === true) {
         ),
     );
     $editMenuSelectMenuForm->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
-    $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>Which menu do you wish to edit?</h3>' . $editMenuSelectMenuForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage1')));
+    $sdmassembler->sdmAssemblerIncorporateAppOutput('<h3>Which menu do you wish to edit?</h3>' . $editMenuSelectMenuForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage1')));
 } else {
-    $sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<h3>There are no menus to edit.</h3>', array('incpages' => array('navigationManagerEditMenuStage1')));
+    $sdmassembler->sdmAssemblerIncorporateAppOutput('<h3>There are no menus to edit.</h3>', array('incpages' => array('navigationManagerEditMenuStage1')));
 }

--- a/core/apps/navigationManager/stages/editmenustage2.php
+++ b/core/apps/navigationManager/stages/editmenustage2.php
@@ -125,4 +125,4 @@ foreach ($menuItems as $menuItem) {
 $output .= '</ul></div>';
 $addMenuItemArguments = array('page=navigationManagerEditMenuStage3_addmenuitem', 'menuId=' . $menu->menuId, 'linkedBy=navigationManager_editmenustage2_addMenuItemLink');
 $output .= '<p><a href="' . $sdmassembler->sdmCoreGetRootDirectoryUrl() . '/index.php?' . str_replace('%26', '&', str_replace('%3D', '=', urlencode(implode('&', $addMenuItemArguments)))) . '">Add Menu Item</a></p>';
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $output . '<h3>Menu Settings</h3>' . $editMenuSelectMenuForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage2')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($output . '<h3>Menu Settings</h3>' . $editMenuSelectMenuForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage2')));

--- a/core/apps/navigationManager/stages/editmenustage3_addmenuitem.php
+++ b/core/apps/navigationManager/stages/editmenustage3_addmenuitem.php
@@ -107,4 +107,4 @@ $addMenuItemForm->form_elements = array(
     ),
 );
 $addMenuItemForm->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $addMenuItemForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage3_addmenuitem')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($addMenuItemForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage3_addmenuitem')));

--- a/core/apps/navigationManager/stages/editmenustage3_confirmdeletemenuitem.php
+++ b/core/apps/navigationManager/stages/editmenustage3_confirmdeletemenuitem.php
@@ -45,4 +45,4 @@ $cancelForm->form_elements = array(
     ),
 );
 $cancelForm->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Are you sure you wish to delete menu item "<b>' . $menuItemName . '</b>" with id "<b>' . $menuItemId . '</b>" from menu "<b>' . $menuName . '</b>" with id "<b>' . $menuId . '</b>"?</p>' . $deleteForm->sdmFormGetForm() . $cancelForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage3_confirmdeletemenuitem')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<p>Are you sure you wish to delete menu item "<b>' . $menuItemName . '</b>" with id "<b>' . $menuItemId . '</b>" from menu "<b>' . $menuName . '</b>" with id "<b>' . $menuId . '</b>"?</p>' . $deleteForm->sdmFormGetForm() . $cancelForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage3_confirmdeletemenuitem')));

--- a/core/apps/navigationManager/stages/editmenustage3_deletemenuitem.php
+++ b/core/apps/navigationManager/stages/editmenustage3_deletemenuitem.php
@@ -9,4 +9,4 @@ $menuName = $menu->menuDisplayName;
 $menuItemName = $menu->menuItems->$menuItemId->menuItemDisplayName;
 // delete the menu item
 $sdmnms->sdmNmsDeleteMenuItem($menuId, $menuItemId);
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Deleted menu item "<b>' . $menuItemName . '</b>" with id "<b>' . $menuItemId . '</b>" from menu "<b>' . $menuName . '</b>" with id "<b>' . $menuId . '</b>".</p>', array('incpages' => array('navigationManagerEditMenuStage3_deletemenuitem')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<p>Deleted menu item "<b>' . $menuItemName . '</b>" with id "<b>' . $menuItemId . '</b>" from menu "<b>' . $menuName . '</b>" with id "<b>' . $menuId . '</b>".</p>', array('incpages' => array('navigationManagerEditMenuStage3_deletemenuitem')));

--- a/core/apps/navigationManager/stages/editmenustage3_editmenuitem.php
+++ b/core/apps/navigationManager/stages/editmenustage3_editmenuitem.php
@@ -107,4 +107,4 @@ $editMenuItemForm->form_elements = array(
     ),
 );
 $editMenuItemForm->sdmFormBuildForm($sdmassembler->sdmCoreGetRootDirectoryUrl());
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, $editMenuItemForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage3_editmenuitem')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput($editMenuItemForm->sdmFormGetForm(), array('incpages' => array('navigationManagerEditMenuStage3_editmenuitem')));

--- a/core/apps/navigationManager/stages/editmenustage3_submitaddmenuitem.php
+++ b/core/apps/navigationManager/stages/editmenustage3_submitaddmenuitem.php
@@ -15,4 +15,4 @@ $submittedMenuItem->menuItemMachineName = SdmCore::SdmCoreGenerateMachineName(Sd
 $submittedMenuItem->menuItemPosition = SdmForm::sdmFormGetSubmittedFormValue('menuItemPosition');
 $submittedMenuItem->menuItemWrappingTagType = SdmForm::sdmFormGetSubmittedFormValue('menuItemWrappingTagType');
 $sdmnms->sdmNmsAddMenuItem(SdmForm::sdmFormGetSubmittedFormValue('menuId'), $submittedMenuItem);
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Menu Item Edits Saved Successfully</p>', array('incpages' => array('navigationManagerEditMenuStage3_submitaddmenuitem')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<p>Menu Item Edits Saved Successfully</p>', array('incpages' => array('navigationManagerEditMenuStage3_submitaddmenuitem')));

--- a/core/apps/navigationManager/stages/editmenustage3_submitmenuchanges.php
+++ b/core/apps/navigationManager/stages/editmenustage3_submitmenuchanges.php
@@ -13,4 +13,4 @@ $menu->menuPlacement = SdmForm::sdmFormGetSubmittedFormValue('menuPlacement'); /
 $menu->menuWrappingTagType = SdmForm::sdmFormGetSubmittedFormValue('menuWrappingTagType'); //
 $menu->wrapper = SdmForm::sdmFormGetSubmittedFormValue('wrapper'); //
 $sdmnms->sdmNmsUpdateMenu($menu->menuId, $menu);
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Menu Edits Saved Successfully</p>', array('incpages' => array('navigationManagerEditMenuStage3_submitmenuchanges')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<p>Menu Edits Saved Successfully</p>', array('incpages' => array('navigationManagerEditMenuStage3_submitmenuchanges')));

--- a/core/apps/navigationManager/stages/editmenustage3_submitmenuitemchanges.php
+++ b/core/apps/navigationManager/stages/editmenustage3_submitmenuitemchanges.php
@@ -15,4 +15,4 @@ $submittedMenuItem->menuItemMachineName = SdmCore::SdmCoreGenerateMachineName(Sd
 $submittedMenuItem->menuItemPosition = SdmForm::sdmFormGetSubmittedFormValue('menuItemPosition');
 $submittedMenuItem->menuItemWrappingTagType = SdmForm::sdmFormGetSubmittedFormValue('menuItemWrappingTagType');
 $sdmnms->sdmNmsUpdateMenuItem(SdmForm::sdmFormGetSubmittedFormValue('menuId'), $submittedMenuItem->menuItemId, $submittedMenuItem);
-$sdmassembler->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, '<p>Menu Item Edits Saved Successfully</p>', array('incpages' => array('navigationManagerEditMenuStage3_submitmenuitemchanges')));
+$sdmassembler->sdmAssemblerIncorporateAppOutput('<p>Menu Item Edits Saved Successfully</p>', array('incpages' => array('navigationManagerEditMenuStage3_submitmenuitemchanges')));

--- a/core/config/startup.php
+++ b/core/config/startup.php
@@ -16,4 +16,4 @@ $sdmassembler->sdmCoreConfigureCore();
 // start core session
 $sdmassembler->sessionStart();
 // load and assemble content | this var is used excluisively by the current themes page.php
-$sdmAssemblerThemeContentObject = $sdmassembler->sdmAssemblerLoadAndAssembleContentObject();
+$sdmassembler->sdmAssemblerLoadAndAssembleContentObject();

--- a/core/includes/SdmAssembler.php
+++ b/core/includes/SdmAssembler.php
@@ -257,15 +257,15 @@ class SdmAssembler extends SdmGatekeeper {
         // store SdmAssembler object in an appropriatly named var to give apps easy access
         $sdmassembler = $this;
         // read app gatekeeper parameters
-        $gkParams = SdmGatekeeper::sdmGatekeeperReadAppGkParams($app);
+        $gkParams = $this->sdmGatekeeperReadAppGkParams($app);
         /**
-         * If SdmGatekeeper::sdmGatekeeperReadAppGkParams()
+         * If $this->sdmGatekeeperReadAppGkParams()
          * returned false, then assume app is not restricted to role,
          * if .gk file exists then check the roles parameter to see which roles
          * have permission to use this app, if the roles parameter has the 'all' value
          * in it then all users will be able to use this app.
          */
-        $userClear = ($gkParams === false || in_array(SdmGatekeeper::SdmGatekeeperDetermineUserRole(), $gkParams['roles']) || in_array('all', $gkParams['roles']) ? true : false);
+        $userClear = ($gkParams === false || in_array($this->SdmGatekeeperDetermineUserRole(), $gkParams['roles']) || in_array('all', $gkParams['roles']) ? true : false);
         $appPath = '/' . $app . '/' . $app . '.php';
         if ($userClear === true) {
             // load apps
@@ -410,7 +410,7 @@ class SdmAssembler extends SdmGatekeeper {
             $options['roles'] = array('all');
         }
         // first we check if app output is restricted to certain roles. if it is we check that current user role matches one of the valid roles for the app. If the special 'all' role is in the $options['roles'] array then all users see the app output
-        $validUser = (in_array(SdmGatekeeper::SdmGatekeeperDetermineUserRole(), $options['roles']) || in_array('all', $options['roles']) ? true : false);
+        $validUser = (in_array($this->SdmGatekeeperDetermineUserRole(), $options['roles']) || in_array('all', $options['roles']) ? true : false);
         if ($validUser === true) {
             // Check that $requested page exists in CORE or or is passed in as an option via the options array's incpages array
             if (in_array($requestedPage, $this->sdmCoreDetermineAvailablePages()) === true || in_array($requestedPage, $options['incpages']) === true) {

--- a/core/includes/SdmAssembler.php
+++ b/core/includes/SdmAssembler.php
@@ -180,7 +180,7 @@ class SdmAssembler extends SdmGatekeeper {
     public function sdmAssemblerLoadAndAssembleContentObject() {
         $page = $this->sdmCoreDetermineRequestedPage();
         // load our data object
-        $sdmAssemblerDataObject = $this->sdmCoreGetDataObject();
+        $sdmAssemblerDataObject = $this->DataObject;
         // load and assemble apps
         $this->sdmAssemblerLoadApps($sdmAssemblerDataObject);
         /** make sure content exists, if it does return it, if not, return a content not found message and log the bad request to the bad requests log */

--- a/core/includes/SdmAssembler.php
+++ b/core/includes/SdmAssembler.php
@@ -183,9 +183,11 @@ class SdmAssembler extends SdmGatekeeper {
         $sdmAssemblerDataObject = $this->sdmCoreGetDataObject();
         // load and assemble apps
         $this->sdmAssemblerLoadApps($sdmAssemblerDataObject);
-        // make sure content exists, if it does return it, if not, return a content not found message and log the bad request to the bad requests log
-        switch (isset($sdmAssemblerDataObject->content->$page)) {
-            case true:
+        /** make sure content exists, if it does return it, if not, return a content not found message and log the bad request to the bad requests log */
+        // cast $sdmAssemblerDataObject->content->$page to an array so we can test if it is empty or not, works better then isset because the $sdmAssemblerDataObject->content->$page object may exist with no properties.
+        $pageContent = (array) $sdmAssemblerDataObject->content->$page;
+        switch (empty($pageContent)) {
+            case false:
                 //var_dump($sdmAssemblerDataObject->content->$page);
                 $sdmAssemblerDataObject = $this->sdmAssemblerPreparePageForDisplay($sdmAssemblerDataObject->content->$page);
                 return $sdmAssemblerDataObject;

--- a/core/includes/SdmAssembler.php
+++ b/core/includes/SdmAssembler.php
@@ -181,7 +181,7 @@ class SdmAssembler extends SdmGatekeeper {
         // determine requested page
         $page = $this->sdmCoreDetermineRequestedPage();
         // load and assemble apps
-        $this->sdmAssemblerLoadApps($this->DataObject);
+        $this->sdmAssemblerLoadApps();
         /** make sure content exists, if it does return it, if not, return a content not found message and log the bad request to the bad requests log */
         // cast $sdmAssemblerDataObject->content->$page to an array so we can test if it is empty or not, works better then isset because the $sdmAssemblerDataObject->content->$page object may exist with no properties.
         $pageContent = (array) $this->DataObject->content->$page;
@@ -237,10 +237,10 @@ class SdmAssembler extends SdmGatekeeper {
      * $this->sdmAssemblerLoadApp() fails to load an app as a result of user having insufficient
      * privlages. Only actual failures will result in this method returning false.</i></p>
      */
-    private function sdmAssemblerLoadApps($sdmAssemblerDataObject) {
+    private function sdmAssemblerLoadApps() {
         $enabledApps = $this->sdmCoreDetermineEnabledApps();
         foreach ($enabledApps as $app) {
-            $status[] = $this->sdmAssemblerLoadApp($app, $sdmAssemblerDataObject);
+            $status[] = $this->sdmAssemblerLoadApp($app);
         }
         return (in_array(false, $status, true));
     }
@@ -253,11 +253,11 @@ class SdmAssembler extends SdmGatekeeper {
      * of an error, such as the app not being found, or the string 'accessDenied' if app was
      * not loaded as a result of user not having sufficient privlages to use app.</p>
      */
-    private function sdmAssemblerLoadApp($app, $sdmAssemblerDataObject) {
-        // store SdmAssembler object in an appropriatly named var to give apps easy access
+    private function sdmAssemblerLoadApp($app) {
+        // we make a copy of $this so apps will be able to utilize $this in their code through the $sdmassembler var. Basically, since we can't use $this from within our apps code, and even if we could it would not be wise as it would not be clear what $this was, $sdmassembler functions as a named alias so apps can do things like call $sdmassembler->SdmCoreSdmReadArray() from within their code.
         $sdmassembler = $this;
         // read app gatekeeper parameters
-        $gkParams = $this->sdmGatekeeperReadAppGkParams($app);
+        $gkParams = $sdmassembler->sdmGatekeeperReadAppGkParams($app);
         /**
          * If $this->sdmGatekeeperReadAppGkParams()
          * returned false, then assume app is not restricted to role,
@@ -265,23 +265,23 @@ class SdmAssembler extends SdmGatekeeper {
          * have permission to use this app, if the roles parameter has the 'all' value
          * in it then all users will be able to use this app.
          */
-        $userClear = ($gkParams === false || in_array($this->SdmGatekeeperDetermineUserRole(), $gkParams['roles']) || in_array('all', $gkParams['roles']) ? true : false);
+        $userClear = ($gkParams === false || in_array($sdmassembler->SdmGatekeeperDetermineUserRole(), $gkParams['roles']) || in_array('all', $gkParams['roles']) ? true : false);
         $appPath = '/' . $app . '/' . $app . '.php';
         if ($userClear === true) {
             // load apps
-            if (file_exists($this->sdmCoreGetCoreAppDirectoryPath() . $appPath)) {
-                require_once($this->sdmCoreGetCoreAppDirectoryPath() . $appPath);
+            if (file_exists($sdmassembler->sdmCoreGetCoreAppDirectoryPath() . $appPath)) {
+                require_once($sdmassembler->sdmCoreGetCoreAppDirectoryPath() . $appPath);
                 return true;
-            } else if (file_exists($this->sdmCoreGetUserAppDirectoryPath() . $appPath)) {
-                require($this->sdmCoreGetUserAppDirectoryPath() . $appPath);
+            } else if (file_exists($sdmassembler->sdmCoreGetUserAppDirectoryPath() . $appPath)) {
+                require($sdmassembler->sdmCoreGetUserAppDirectoryPath() . $appPath);
                 return true;
             }
             // failed to load app | log error to error log so admin can debug problem.
-            error_log('Warning: SdmAssembler() could not load app "' . $app . '". Make sure the app is installed in either the core or user app directory and that it is configured properly. This error most likely occured becuase the assmebler could not locate the "' . $app . '" app at either "' . $this->sdmCoreGetCoreAppDirectoryPath() . $appPath . '" or "' . $this->sdmCoreGetUserAppDirectoryPath() . $appPath . '"');
+            error_log('Warning: SdmAssembler() could not load app "' . $app . '". Make sure the app is installed in either the core or user app directory and that it is configured properly. This error most likely occured becuase the assmebler could not locate the "' . $app . '" app at either "' . $sdmassembler->sdmCoreGetCoreAppDirectoryPath() . $appPath . '" or "' . $sdmassembler->sdmCoreGetUserAppDirectoryPath() . $appPath . '"');
             return false;
         }
         // user does not have permission to use this app
-        $this->sdmAssemblerIncorporateAppOutput($sdmAssemblerDataObject, 'You do not have permission to be here.', array('incpages' => array($app)));
+        $sdmassembler->sdmAssemblerIncorporateAppOutput('You do not have permission to be here.', array('incpages' => array($app)));
         return 'accessDenied';
     }
 
@@ -317,16 +317,6 @@ class SdmAssembler extends SdmGatekeeper {
      * to the page argument in the url and the SDM CMS would gnereate a page for it.
      * <br /><br />i.e, http://example.com/index.php?page=NonExistentPage would work if we did not check for it in CORE
      * and in the 'incpages' array</p>
-     * @param object $dataObject <p style="font-size:9px;">The sites data object. (This is most likely the
-     * $sdmAssemblerDataObject var provided by the SDM_Assembler)<br />
-     * Note: We need to typehint for security, however PHP has no common
-     * object ancestor so we cant specify <i>object</i> because most likely
-     * the type of this argument will be an instance of stdClass, which is
-     * technically an object but will not neccessarily return as type object
-     * when checked with typehinting.<b>*</b><br />
-     * @see <b>*</b>http://stackoverflow.com/questions/13287593/stdclass-and-type-hinting for more
-     * info on why this happens.<br />@TODO: It may be best NOT to typehint the $dataObject
-     * argument as it may introduce bugs if an actual object is passed to this method.</p>
      * @param string $output <p style="font-size:9px;"p>A plain text or HTML string to be used as the apps output.</p>
      * @param array $options (optional) <p style="font-size:9px;">Array of options that determine how an app's
      * output is incorporated. If not specified, then the app will be incorporated into
@@ -370,7 +360,7 @@ class SdmAssembler extends SdmGatekeeper {
      * will be displayed at the top of the page for the most every call to this method for the requested page. This is useful when developing apps.</p>
      * @return object <p style="font-size:9px;">The modified data object.</p>
      */
-    public function sdmAssemblerIncorporateAppOutput(stdClass $dataObject, $output, array $options = array(), $devmode = false) {
+    public function sdmAssemblerIncorporateAppOutput($output, array $options = array(), $devmode = false) {
         // determine which app this output came from
         $calledby = ucwords(preg_replace('/(?<!\ )[A-Z]/', ' $0', str_replace(array('/', '.php'), '', strrchr(debug_backtrace()[0]['file'], '/')))); // trys to determine which app called this method using debug_backtrace() @see http://php.net/manual/en/function.debug-backtrace.php | basically were just filtering the name path of the file that this method was called to so it displays in a format that is easy to read, we know that the calling file will contain the app name since all apps must name their main php file according to this case insensitive naming convention : APPNAME.php
         // determine the requested page
@@ -398,8 +388,8 @@ class SdmAssembler extends SdmGatekeeper {
              * Also note that if inpages is empty then it will be assumed the developer
              * does NOT want to incorporate app output into any page.
              * i.e.,
-             *   sdmAssemblerIncorporateAppOutput($dataObject, $output, array('incpages' => array());// app out put will NOT be incorporated into any pages because incpages is empty
-             *   sdmAssemblerIncorporateAppOutput($dataObject, $output);// app out put will be incorporated into all pages because incpages does not exist, and will therefore be created and configured with pre-determined internal default values
+             *   sdmAssemblerIncorporateAppOutput($this->DataObject, $output, array('incpages' => array());// app out put will NOT be incorporated into any pages because incpages is empty
+             *   sdmAssemblerIncorporateAppOutput($this->DataObject, $output);// app out put will be incorporated into all pages because incpages does not exist, and will therefore be created and configured with pre-determined internal default values
              */
             $pages = $this->sdmCoreDetermineAvailablePages();
             $enabledApps = json_decode(json_encode($this->sdmCoreDetermineEnabledApps()), true);
@@ -416,47 +406,47 @@ class SdmAssembler extends SdmGatekeeper {
             if (in_array($requestedPage, $this->sdmCoreDetermineAvailablePages()) === true || in_array($requestedPage, $options['incpages']) === true) {
                 /* DATAOBJECT check | Make sure the properties we are modifying exist to prevent throwing any PHP errors */
                 // if no page exists for app in the CORE, then create a placeholder object for it to avoid PHP Errors, Notices, and Warnings
-                if (!isset($dataObject->content->$requestedPage)) {
-                    $dataObject->content->$requestedPage = new stdClass();
+                if (!isset($this->DataObject->content->$requestedPage)) {
+                    $this->DataObject->content->$requestedPage = new stdClass();
                 }
                 // if target wrapper doesn't exist then create a placeholder for it to avoid any PHP Errors, Notices, or Warnings
-                if (!isset($dataObject->content->$requestedPage->$options['wrapper'])) {
-                    $dataObject->content->$requestedPage->$options['wrapper'] = '';
+                if (!isset($this->DataObject->content->$requestedPage->$options['wrapper'])) {
+                    $this->DataObject->content->$requestedPage->$options['wrapper'] = '';
                 }
 
                 // make sure requested page is not in the ignorepages array
                 if (!in_array($requestedPage, $options['ignorepages'])) {
                     // PRE PROCESSING DEV MODE OUTPUT
                     if ($devmode === true) {
-                        $this->sdmCoreSdmReadArray(array('Call To Method' => 'sdmAssemblerIncorporateAppOutput()', 'Method called by app' => $calledby, 'STAGE' => 'PRE_PROCESSING', 'OPTIONS' => $options, 'App Output' => $output, 'Data Object State' => $dataObject,));
+                        $this->sdmCoreSdmReadArray(array('Call To Method' => 'sdmAssemblerIncorporateAppOutput()', 'Method called by app' => $calledby, 'STAGE' => 'PRE_PROCESSING', 'OPTIONS' => $options, 'App Output' => $output, 'Data Object State' => $this->DataObject,));
                     }
                     // if not in ignorepages array and incpages is empty assume any page not in ignore array can incorporate app output
                     // Only incorporate app output if requested page matches one of the items in incpages
                     if (in_array($requestedPage, $options['incpages'], true)) {
                         if ($options['incmethod'] === 'prepend') {
-                            $dataObject->content->$requestedPage->$options['wrapper'] = $output . $dataObject->content->$requestedPage->$options['wrapper'];
+                            $this->DataObject->content->$requestedPage->$options['wrapper'] = $output . $this->DataObject->content->$requestedPage->$options['wrapper'];
                             // PREPEND DEV MODE OUTPUT
                             if ($devmode === true) {
-                                $this->sdmCoreSdmReadArray(array('Call To Method' => 'sdmAssemblerIncorporateAppOutput()', 'Method called by app' => $calledby, 'STAGE' => 'PREPENDING', 'OPTIONS' => $options, 'App Output' => $output, 'Data Object State' => $dataObject,));
+                                $this->sdmCoreSdmReadArray(array('Call To Method' => 'sdmAssemblerIncorporateAppOutput()', 'Method called by app' => $calledby, 'STAGE' => 'PREPENDING', 'OPTIONS' => $options, 'App Output' => $output, 'Data Object State' => $this->DataObject,));
                             }
                         } else if ($options['incmethod'] === 'overwrite') {
-                            $dataObject->content->$requestedPage->$options['wrapper'] = $output;
+                            $this->DataObject->content->$requestedPage->$options['wrapper'] = $output;
                             // OVERWRITE DEV MODE OUTPUT
                             if ($devmode === true) {
-                                $this->sdmCoreSdmReadArray(array('Call To Method' => 'sdmAssemblerIncorporateAppOutput()', 'Method called by app' => $calledby, 'STAGE' => 'OVERWRITEING', 'OPTIONS' => $options, 'App Output' => $output, 'Data Object State' => $dataObject,));
+                                $this->sdmCoreSdmReadArray(array('Call To Method' => 'sdmAssemblerIncorporateAppOutput()', 'Method called by app' => $calledby, 'STAGE' => 'OVERWRITEING', 'OPTIONS' => $options, 'App Output' => $output, 'Data Object State' => $this->DataObject,));
                             }
                         } else { // default is to append
-                            $dataObject->content->$requestedPage->$options['wrapper'] .= $output;
+                            $this->DataObject->content->$requestedPage->$options['wrapper'] .= $output;
                             // APPEND (default) DEV MODE OUTPUT
                             if ($devmode === true) {
-                                $this->sdmCoreSdmReadArray(array('Call To Method' => 'sdmAssemblerIncorporateAppOutput()', 'Method called by app' => $calledby, 'STAGE' => 'APPENDING', 'OPTIONS' => $options, 'App Output' => $output, 'Data Object State' => $dataObject,));
+                                $this->sdmCoreSdmReadArray(array('Call To Method' => 'sdmAssemblerIncorporateAppOutput()', 'Method called by app' => $calledby, 'STAGE' => 'APPENDING', 'OPTIONS' => $options, 'App Output' => $output, 'Data Object State' => $this->DataObject,));
                             }
                         }
                     }
                 } // do nothing if in requested page is in ignore pages
             } // end check if requested page exists in CORE or as an enabled app
         } // end check roles
-        return $dataObject;
+        return $this->DataObject;
     }
 
     /**

--- a/core/includes/SdmAssembler.php
+++ b/core/includes/SdmAssembler.php
@@ -190,7 +190,10 @@ class SdmAssembler extends SdmGatekeeper {
             case false:
                 //var_dump($sdmAssemblerDataObject->content->$page);
                 $sdmAssemblerDataObject = $this->sdmAssemblerPreparePageForDisplay($sdmAssemblerDataObject->content->$page);
-                return $sdmAssemblerDataObject;
+                // now we need to update $this->DataObject with our changes
+                unset($this->DataObject);
+                $this->DataObject = $sdmAssemblerDataObject;
+                return true;
             default:
                 // log bad request to our badRequestsLog.log file
                 $badRequestId = chr(rand(65, 90)) . rand(10, 99) . chr(rand(65, 90)) . rand(10, 99);
@@ -464,16 +467,12 @@ class SdmAssembler extends SdmGatekeeper {
      * <p>Assembles the html content for a given $wrapper and returns it as a string. This method
      * is meant to be called from within a themes page.php file.</p>
      * @param string $wrapper <p>The wrapper to assemble html</p>
-     * @param stdClass $dataObject <p>The $sdmAssemblerThemeContentObject variable that is created
-     * by startup.php's call to SdmAssembler::sdmAssemblerLoadAndAssembleContentObject() during the
-     * startup process. The $sdmAssemblerThemeContentObject is always avaialbe to all themes.
-     * <br>See: <i>/core/config/startup.php</i> for more info</p>
      * @return type
      */
-    public static function sdmAssemblerGetContentHtml($wrapper, stdClass $sdmAssemblerThemeContentObject) {
+    public function sdmAssemblerGetContentHtml($wrapper) {
         // initialize the SdmNms so we can add our menus to the page.
         $nms = new SdmNms();
-        $wrapperAssembledContent = (isset($sdmAssemblerThemeContentObject->$wrapper) ? $sdmAssemblerThemeContentObject->$wrapper : '<!-- ' . $wrapper . ' placeholder -->');
+        $wrapperAssembledContent = (isset($this->DataObject->$wrapper) ? $this->DataObject->$wrapper : '<!-- ' . $wrapper . ' placeholder -->');
         $content = $nms->sdmNmsGetWrapperMenusHtml($wrapper, $wrapperAssembledContent);
         return $content;
     }

--- a/core/includes/SdmCms.php
+++ b/core/includes/SdmCms.php
@@ -25,7 +25,7 @@ class SdmCms extends SdmCore {
      * @return int The number of bytes written to data.json or the DB. Returns false on failure.
      */
     public function sdmCmsUpdateContent($page, $id, $html) {
-        $content = $this->sdmCoreGetDataObject();
+        $content = $this->sdmCoreLoadDataObject(false);
         // filter out problematic charaters from $html and insure UTF-8 using iconv()
         $filteredHtml = iconv("UTF-8", "UTF-8//IGNORE", $html);
         $filteredHtml2 = iconv("UTF-8", "ISO-8859-1//IGNORE", $filteredHtml);
@@ -101,7 +101,7 @@ class SdmCms extends SdmCore {
      * @return int The number of bytes written to data.json or the DB. Returns false on failure.
      */
     public function sdmCmsChangeTheme($theme) {
-        $data = $this->sdmCoreGetDataObject();
+        $data = $this->sdmCoreLoadDataObject(false);
         $data->settings->theme = $theme;
         $jsondata = json_encode($data);
         return file_put_contents($this->sdmCoreGetDataDirectoryPath() . '/data.json', $jsondata, LOCK_EX);
@@ -112,7 +112,7 @@ class SdmCms extends SdmCore {
      * @param string $pagename Name of the page to delete.
      */
     public function sdmCmsDeletePage($pagename) {
-        $data = $this->sdmCoreGetDataObject();
+        $data = $this->sdmCoreLoadDataObject(false);
         unset($data->content->$pagename);
         $jsondata = json_encode($data);
         return file_put_contents($this->sdmCoreGetDataDirectoryPath() . '/data.json', $jsondata, LOCK_EX);
@@ -150,7 +150,7 @@ class SdmCms extends SdmCore {
      * @return bool true on sucessful state change, false if unable to switch state.
      */
     public function sdmCmsSwitchAppState($app, $state) {
-        $data = $this->sdmCoreGetDataObject();
+        $data = $this->sdmCoreLoadDataObject(false);
         $enabledApps = $data->settings->enabledapps;
         switch ($state) {
             case 'on':

--- a/core/includes/SdmCore.php
+++ b/core/includes/SdmCore.php
@@ -440,14 +440,11 @@ class SdmCore {
     }
 
     /**
-     * <p>Determines what apps are enabled by checking the property
-     * values of the Enabled Apps object</p>
-     * @return object An object whose properties are apps that are currently enabled.
+     * <p>Returns object stored in DataObject->settings->enabledapps.</p>
+     * @return object <p>$this->DataObject->settings->enabledapps.</p>
      */
     final public function sdmCoreDetermineEnabledApps() {
-        $data = $this->sdmCoreGetDataObject();
-        $enabledApps = $data->settings->enabledapps;
-        return $enabledApps;
+        return $this->DataObject->settings->enabledapps;
     }
 
     /**

--- a/core/includes/SdmCore.php
+++ b/core/includes/SdmCore.php
@@ -31,7 +31,7 @@ class SdmCore {
     private $DataDirectoryUrl;
     private $requestedPage;
     // in dev
-    private $DataObject;
+    protected $DataObject;
 
     final public function __construct() {
         // we need to do some special filetering to determine the Root Directory Path and Url
@@ -238,6 +238,8 @@ class SdmCore {
      * @return object <p>The content object loaded from $this->CoreDirectoryUrl/sdm/data.json or from the DB</p>
      */
     final public function sdmCoreLoadDataObject($requestPageOnly = true) {
+        $_SESSION['Data Object Loaded'] = (isset($_SESSION['Data Object Loaded']) ? $_SESSION['Data Object Loaded'] + 1 : 1);
+        $this->sdmCoreSdmReadArray(array('Times Data Object Loaded' => $_SESSION['Data Object Loaded']));
         // determine requested page
         $requestedPage = $this->sdmCoreDetermineRequestedPage();
         // load json string from data.json via curl

--- a/core/includes/SdmCore.php
+++ b/core/includes/SdmCore.php
@@ -486,7 +486,7 @@ class SdmCore {
      * @param type $end <p>The ending string, i.e., the chars to end the slice at</p>
      * @return string <p>The slice of the string between $start and $end.</p>
      */
-    final public static function sdmCoreStrSlice($string, $start, $end) {
+    final public function sdmCoreStrSlice($string, $start, $end) {
         $string = " " . $string;
         $ini = strpos($string, $start);
         if ($ini == 0) {

--- a/core/includes/SdmCore.php
+++ b/core/includes/SdmCore.php
@@ -238,8 +238,6 @@ class SdmCore {
      * @return object <p>The content object loaded from $this->CoreDirectoryUrl/sdm/data.json or from the DB</p>
      */
     final public function sdmCoreLoadDataObject($requestPageOnly = true) {
-        $_SESSION['Data Object Loaded'] = (isset($_SESSION['Data Object Loaded']) ? $_SESSION['Data Object Loaded'] + 1 : 1);
-        $this->sdmCoreSdmReadArray(array('Times Data Object Loaded' => $_SESSION['Data Object Loaded']));
         // determine requested page
         $requestedPage = $this->sdmCoreDetermineRequestedPage();
         // load json string from data.json via curl

--- a/core/includes/SdmGatekeeper.php
+++ b/core/includes/SdmGatekeeper.php
@@ -246,7 +246,7 @@ class SdmGatekeeper extends SdmCore implements SessionHandlerInterface {
      * then the 'anonymous' role is returned.</p>
      * @return string <p>The user role</p>
      */
-    final public static function SdmGatekeeperDetermineUserRole() {
+    final public function SdmGatekeeperDetermineUserRole() {
         return (isset($_SESSION['userRole']) ? $_SESSION['userRole'] : 'anonymous');
     }
 
@@ -266,14 +266,13 @@ class SdmGatekeeper extends SdmCore implements SessionHandlerInterface {
      * @return array <p>Associative array of parameters from the app's .gk
      * file or false if no .gk file is exists.
      */
-    final public static function sdmGatekeeperReadAppGkParams($app) {
-        $gkSdmCore = new SdmCore();
-        if (file_exists($gkSdmCore->sdmCoreGetCoreAppDirectoryPath() . '/' . $app . '/' . $app . '.gk')) {
-            $gkfile = file($gkSdmCore->sdmCoreGetCoreAppDirectoryPath() . '/' . $app . '/' . $app . '.gk');
-            $params = SdmGatekeeper::sdmGatekeeperDecodeParams($gkfile);
-        } else if (file_exists($gkSdmCore->sdmCoreGetUserAppDirectoryPath() . '/' . $app . '/' . $app . '.gk')) {
-            $gkfile = file($gkSdmCore->sdmCoreGetUserAppDirectoryPath() . '/' . $app . '/' . $app . '.gk');
-            $params = SdmGatekeeper::sdmGatekeeperDecodeParams($gkfile);
+    final public function sdmGatekeeperReadAppGkParams($app) {
+        if (file_exists($this->sdmCoreGetCoreAppDirectoryPath() . '/' . $app . '/' . $app . '.gk')) {
+            $gkfile = file($this->sdmCoreGetCoreAppDirectoryPath() . '/' . $app . '/' . $app . '.gk');
+            $params = $this->sdmGatekeeperDecodeParams($gkfile);
+        } else if (file_exists($this->sdmCoreGetUserAppDirectoryPath() . '/' . $app . '/' . $app . '.gk')) {
+            $gkfile = file($this->sdmCoreGetUserAppDirectoryPath() . '/' . $app . '/' . $app . '.gk');
+            $params = $this->sdmGatekeeperDecodeParams($gkfile);
         } else {
             $params = false;
         }
@@ -291,10 +290,10 @@ class SdmGatekeeper extends SdmCore implements SessionHandlerInterface {
      * </p>
      * @return array <p>Associative array of .gk params decoded from an array returned by loading a .gk file via file()</p>
      */
-    final private static function sdmGatekeeperDecodeParams($gkfile) {
+    final private function sdmGatekeeperDecodeParams($gkfile) {
         foreach ($gkfile as $value) {
-            $paramName = SdmCore::sdmCoreStrSlice('->' . $value, '->', '=');
-            $paramValuesString = SdmCore::sdmCoreStrSlice($value, '=', ';');
+            $paramName = $this->sdmCoreStrSlice('->' . $value, '->', '=');
+            $paramValuesString = $this->sdmCoreStrSlice($value, '=', ';');
             $paramValuesArray[$paramName] = explode(',', $paramValuesString);
         }
         return $paramValuesArray;

--- a/core/includes/SdmNms.php
+++ b/core/includes/SdmNms.php
@@ -129,7 +129,7 @@ class SdmNms extends SdmCore {
             $menu = json_decode(json_encode($menu));
         }
         // load our core data object
-        $data = $this->sdmCoreGetDataObject();
+        $data = $this->sdmCoreLoadDataObject(false);
         // either load stored menus object from our core data object or if no menus exist yet initilize a default object using stdClass()
         $menus = (isset($data->menus) === true ? $data->menus : new stdClass());
         // store the new $menu in $menus under it's $menu->menuId
@@ -158,7 +158,7 @@ class SdmNms extends SdmCore {
         // get menu item id
         $menuItemId = $menuItem->menuItemId;
         // load our core data object
-        $data = $this->sdmCoreGetDataObject();
+        $data = $this->sdmCoreLoadDataObject(false);
         // add menu item to menu
         $data->menus->$menuId->menuItems->$menuItemId = $menuItem;
         // encode $data as json to prep it for storage
@@ -187,7 +187,7 @@ class SdmNms extends SdmCore {
             $menu = json_decode(json_encode($menu));
         }
         // load our core data object
-        $data = $this->sdmCoreGetDataObject();
+        $data = $this->sdmCoreLoadDataObject(false);
         // load stored menus object from our core data object
         $menus = json_decode(json_encode($data->menus));
         // update menu with menuId === $menuId
@@ -217,7 +217,7 @@ class SdmNms extends SdmCore {
      */
     public function sdmNmsUpdateMenuItem($menuId, $menuItemId, $menuItem) {
         // load our core data object
-        $data = $this->sdmCoreGetDataObject();
+        $data = $this->sdmCoreLoadDataObject(false);
         // load stored menus object from our core data object
         $menus = $data->menus;
         // get the menu this menu item belongs to
@@ -244,7 +244,7 @@ class SdmNms extends SdmCore {
      * deleted then the boolean false is returned.</p>
      */
     public function sdmNmsDeleteMenu($menuId) {
-        $data = $this->sdmCoreGetDataObject();
+        $data = $this->sdmCoreLoadDataObject(false);
         $menuDisplayName = $data->menus->$menuId->menuDisplayName;
         unset($data->menus->$menuId);
         $json = json_encode($data);
@@ -259,7 +259,7 @@ class SdmNms extends SdmCore {
       @return mixed <p>If menu item was deleted then the display name of the deleted menu item is returned, if menu item could not be
      * deleted then the boolean false is returned.</p>     */
     public function sdmNmsDeleteMenuItem($menuId, $menuItemId) {
-        $data = $this->sdmCoreGetDataObject();
+        $data = $this->sdmCoreLoadDataObject(false);
         $menuItemDisplayName = $data->menus->$menuId->menuItems->$menuItemId->menuItemDisplayName;
         unset($data->menus->$menuId->menuItems->$menuItemId);
         $json = json_encode($data);
@@ -276,7 +276,7 @@ class SdmNms extends SdmCore {
      * @return string <p>The html for the menus.</p>
      */
     public function sdmNmsGetWrapperMenusHtml($wrapper, $wrapperAssembledContent) {
-        $data = $this->sdmCoreGetDataObject();
+        $data = $this->sdmCoreLoadDataObject(false);
         $prepend = '';
         $append = '';
         if (isset($data->menus)) {
@@ -318,7 +318,7 @@ class SdmNms extends SdmCore {
      * @return object <p>The menu with id $menuId</p>
      */
     public function sdmNmsGetMenu($menuId) {
-        $data = $this->sdmCoreGetDataObject();
+        $data = $this->sdmCoreLoadDataObject(false);
         return $data->menus->$menuId;
     }
 
@@ -329,7 +329,7 @@ class SdmNms extends SdmCore {
      * @return object <p>The menu item with id $menuItemId that belongs to the menu with id $menuId</p>
      */
     public function sdmNmsGetMenuItem($menuId, $menuItemId) {
-        $data = $this->sdmCoreGetDataObject();
+        $data = $this->sdmCoreLoadDataObject(false);
         $menu = $data->menus->$menuId;
         return $menu->menuItems->$menuItemId;
     }
@@ -406,7 +406,7 @@ class SdmNms extends SdmCore {
      * @return array <p>An array of all available menus indexed by menu->$propKey with values set to menu->$propValue</p>
      */
     public function sdmNmsGenerateMenuPropertiesArray($propKey, $propValue) {
-        $menus = $this->sdmCoreGetDataObject()->menus;
+        $menus = $this->sdmCoreLoadDataObject(false)->menus;
         foreach ($menus as $menu) {
             $availableMenus[$menu->$propKey] = $menu->$propValue;
         }
@@ -418,7 +418,7 @@ class SdmNms extends SdmCore {
      * @return type <p>An array of menu ids for all available menus.</p>
      */
     public function sdmNmsGetMenuIds() {
-        return array_keys(json_decode(json_encode($this->sdmCoreGetDataObject()->menus), true));
+        return array_keys(json_decode(json_encode($this->sdmCoreLoadDataObject(false)->menus), true));
     }
 
     /**
@@ -427,7 +427,7 @@ class SdmNms extends SdmCore {
      * @return type <p>An array of menu item ids for all menu items beloning to the menu.</p>
      */
     public function sdmNmsGetMenuItemIds($menuId) {
-        $menu = $this->sdmCoreGetDataObject()->menus->$menuId;
+        $menu = $this->sdmCoreLoadDataObject(false)->menus->$menuId;
         return array_keys(json_decode(json_encode($menu->menuItems), true));
     }
 

--- a/themes/sdmResponsive/page.php
+++ b/themes/sdmResponsive/page.php
@@ -2,27 +2,27 @@
 <div class="row row-min-wid-fix">
     <div id="top-menu"class="col-12 col-m-12 border-bottom">
         <?php
-        echo SdmAssembler::sdmAssemblerGetContentHtml('top-menu', $sdmAssemblerThemeContentObject);
+        echo $sdmassembler->sdmAssemblerGetContentHtml('top-menu');
         ?>
     </div>
 </div>
 <!-- row 2 -->
 <div class="row row-min-wid-fix padded-row">
     <?php
-    $sidebar = SdmAssembler::sdmAssemblerGetContentHtml('side-menu', $sdmAssemblerThemeContentObject);
+    $sidebar = $sdmassembler->sdmAssemblerGetContentHtml('side-menu');
     $sidebarInvalidValues = array(null, '', '<!-- side-menu placeholder -->');
     $sideBarExists = (in_array($sidebar, $sidebarInvalidValues) === true ? false : true);
     if ($sideBarExists === true) {
         ?>
         <div id="side-menu" class="col-3 col-m-3 rounded">
             <?php
-            echo SdmAssembler::sdmAssemblerGetContentHtml('side-menu', $sdmAssemblerThemeContentObject);
+            echo $sdmassembler->sdmAssemblerGetContentHtml('side-menu');
             ?>    </div>
         <div id="locked-spacer" class="col-1 col-m-1 spacer"></div>
     <?php } ?>
     <div id="main_content"class="<?php echo ($sideBarExists === true ? 'col-8 col-m-8' : 'col-12 col-m-12'); ?> rounded">
         <?php
-        echo SdmAssembler::sdmAssemblerGetContentHtml('main_content', $sdmAssemblerThemeContentObject);
+        echo $sdmassembler->sdmAssemblerGetContentHtml('main_content');
         ?>
     </div>
 </div>
@@ -30,7 +30,7 @@
 <div class="row row-min-wid-fix">
     <div id="footer"class="col-12 col-m-12">
         <?php
-        echo SdmAssembler::sdmAssemblerGetContentHtml('footer', $sdmAssemblerThemeContentObject);
+        echo $sdmassembler->sdmAssemblerGetContentHtml('footer');
         ?>
     </div>
 </div>


### PR DESCRIPTION
Major refactoring of many components. The DataObject is now being referenced internally by the various methods that utilize it, including SdmAssembler()::sdmAssemblerGetContentHtml() and SdmAssembler::sdmAssemblerIncorporateAppOutput() which no longer expect a reference to the data object to be passed as a parameter when calling these methods. Updated CRUD components to conform to the changes in how Core components utilize the DataObject. SdmCore()::sdmCoreStrSlice(), SdmGatekeeper()::SdmGatekeeperDetermineUserRole(), and SdmGatekeeper()::sdmGatekeeperReadAppGkParams() are no longer a static methods. Replaced static calls to these methods in components that utilize these methods. Some other minor refactoring and code cleanup in various components, see commit messages for November 12 - November 16 2015 for more details.