### PR TITLE
Sdmcms cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ that will allow admin to switch to a database for storage. The supported
 databases at first will most likely be MySql and SQLite, also considering Mongo DB.
 
 Im currently working on the documentation for the SDM CMS, and as soon as
-I finish checking for typos and insuring clarity the documentation will
+I finished checking for typos and insuring clarity the documentation will
 be available.
 
 I built this CMS out of a love for coding, particularly in PHP. I had worked with other CMS's

--- a/README.md
+++ b/README.md
@@ -1,6 +1,32 @@
 # SDM_CMS
-A unique JSON driven CMS. Still in development, this CMS is being designed to be easily hackable, 
-and totally usable without any configuration outside of the user interface.
+A unique JSON driven CMS. Still in development, this CMS is designed to be easy to use, and easy to develop with.
+The user interface provided by the core apps makes it easy to build a site without writing a single line of code,
+and for the more hands on users, the SDM CMS can easily be customized and extended via the development of custom
+themes and user apps.
+
+The SDM CMS uses json to store site data, i.e., in place of a Database a json file is used
+to store site data. Json was chosen because it is highly portable, is highly used,
+and because it is highly compatible with javascript, and other languages, and many
+languages like PHP have built in functions/methods for interacting with json.
+
+@todo: I am planning on developing a core app that will come packaged with the SDM CMS 
+that will allow admin to switch to a database for storage. The supported
+databases at first will most likely be MySql and SQLite, also considering Mongo DB.
+
+Im currently working on the documentation for the SDM CMS, and as soon as
+I finish checking for typos and insuring clarity the documentation will
+be available.
+
+I built this CMS out of a love for coding, particularly in PHP. I had worked with other CMS's
+like Drupal, and WordPress, and wanted a simpler more portable CMS that was easier to grasp
+under the hood. I also wanted to get a better understanding of how a CMS works, and figured
+why not dive in and learn from experience.
+
+I am very passionate about this project, and will continue to develop and improve the SDM CMS.
+
+Thank you for trying out the Sdm Cms.
+
+Sevi Donnelly Foreman
 
 # Codacy Badge
 [![Codacy Badge](https://api.codacy.com/project/badge/grade/5b4c6fabcebe47d2bd7648823c073156)](https://www.codacy.com/app/sdmwebsdm/SDM_CMS)

--- a/apps/gitTools/gitTools.php
+++ b/apps/gitTools/gitTools.php
@@ -17,4 +17,31 @@ $output = "<div style='clear:both;color: #66CCCC; background: #000000; border-ra
 
 $sdmassembler->sdmAssemblerIncorporateAppOutput($output, array('incmethod' => 'prepend'));
 
-$sdmassembler->sdmAssemblerIncorporateAppOutput('<h3>Git Tools</h3><p>This app provides tools for working with git. At the moment the only tool is a <i>branch viewer</i> that show the current git branch at the top of the main_content menu wrapper on every page.</p><p>Further development of this app will occur in the future, and this app will have a variety of tools for using git with your SDM CMS site.</p>', array('incpages' => array('gitTools'), 'incmethod' => 'append'));
+unset($output);
+$output = '
+    <h3>Git Tools</h3>
+        <p>This app provides tools for working with git. When enalbed the current branch will appear at the top of
+        every page\'s main_content wrapper. In addition, the gitTools page displays a variety of information related
+        to your current working branch.</p>
+        <h3 style="color:red;">Warning!</h3>
+        <p style="color:red;">This app should never be enabled on a live site, it uses PHP\'s exec() function which is
+        very dangerous on a live server as it can potentially give a malicious user the power to execute
+        commands on the server your site is hosted on. This app was created for local use by developers, and should
+        only be enabled when working on a local, non-production, site.</p>
+        ';
+
+/* Execute some git commands to create an overview of the current branch */
+$gitOutput = array();
+
+/* Git Status */
+$gitStatus = exec('git status', $gitStatusOutput);
+$gitInfo = '<h4>Git Status:</h4><div style="border: 5px double #ffffff; padding: 20px;">' . implode('<br>', $gitStatusOutput) . '</div>';
+/* Git Log */
+$gitLog = exec('git log master..' . $branchname . ' -stat --no-merges', $gitLogOutput);
+$gitInfo .= '<h4>Git Log:</h4><div style="border: 5px double #ffffff; padding: 20px;">' . implode('<br>', $gitLogOutput) . '</div>';
+
+$output .= '
+    <h3>Overview of Current Branch "' . $branchname . '":</h3>
+    <div style="border: 5px double #ffffff; padding: 20px;">' . $gitInfo . '</div>
+    ';
+$sdmassembler->sdmAssemblerIncorporateAppOutput($output, array('incpages' => array('gitTools'), 'incmethod' => 'append'));

--- a/apps/helloWorld/helloWorld.as
+++ b/apps/helloWorld/helloWorld.as
@@ -1,0 +1,3 @@
+scripts =;
+stylesheets = hw;
+meta =;

--- a/apps/helloWorld/helloWorld.as
+++ b/apps/helloWorld/helloWorld.as
@@ -1,3 +1,2 @@
-scripts =;
-stylesheets = hw;
-meta =;
+scripts=hw;
+stylesheets=hw;

--- a/apps/helloWorld/helloWorld.php
+++ b/apps/helloWorld/helloWorld.php
@@ -3,14 +3,22 @@
 /**
  * This app demonstrates a simple app.
  */
-$output = '<h4>Hello World</h4><p>The helloWorld app demonstrates just how easy it is to create an app for the SDM CMS. Have a peek at it\'s source code for some examples.</p>'; // this string will be sent to the pages in the incpages array, or all pages if incpages is empty or not set
+
+/* Configure incorporation options. */
 $options = array(
     'wrapper' => 'main_content',
     'incmethod' => 'overwrite',
     'incpages' => array('helloWorld'),
     'ignorepages' => array(),
     'roles' => array('root'),
-); // options array determines how an apps output is incorporated into the page
-$devmode = false; // if set to true then dev data about the app output will be displayed on the page as well
-// we use the Sdm Assembler's sdmAssemblerIncorporateAppOutput() method to display our apps output on the page
-$sdmassembler->sdmAssemblerIncorporateAppOutput($output, $options, $devmode);
+);
+
+/* Create some output. */
+$output = '<div id="helloWorld">
+            <h4>Hello World</h4>
+            <p>The helloWorld app demonstrates just how easy it is to create an app for the SDM CMS.
+            Have a peek at it\'s source code for some examples.</p>
+            </div>';
+
+/* Incorporate output. */
+$sdmassembler->sdmAssemblerIncorporateAppOutput($output, $options);

--- a/apps/helloWorld/helloWorld.php
+++ b/apps/helloWorld/helloWorld.php
@@ -10,7 +10,7 @@ $options = array(
     'incmethod' => 'overwrite',
     'incpages' => array('helloWorld'),
     'ignorepages' => array(),
-    'roles' => array('root'),
+    'roles' => array('all'),
 );
 
 /* Create some output. */

--- a/apps/helloWorld/hw.css
+++ b/apps/helloWorld/hw.css
@@ -1,4 +1,4 @@
 #helloWorld {
     color: #00FF99;
-    font-size: 3em;
+    font-size: 4.2em;
 }

--- a/apps/helloWorld/hw.css
+++ b/apps/helloWorld/hw.css
@@ -1,0 +1,4 @@
+#helloWorld {
+    color: #00FF99;
+    font-size: 3em;
+}

--- a/apps/helloWorld/hw.js
+++ b/apps/helloWorld/hw.js
@@ -1,0 +1,3 @@
+$(document).ready(function () {
+    $("#helloWorld").animate({fontSize: "1em", color: "inherit"}, 720);
+});

--- a/apps/jQuery/jquery.php
+++ b/apps/jQuery/jquery.php
@@ -10,3 +10,9 @@ $options = array(
 );
 
 $sdmassembler->sdmAssemblerIncorporateAppOutput($output, $options);
+
+$sdmassembler->sdmAssemblerIncorporateAppOutput('
+<p>Note: The jQuery app must be enabled before any apps or themes dependent on
+jQuery can be used. If an app or theme that depends on jQuery was enabled before
+the jQuery app then you will have to disable the dependent app, make sure jQuery is enabled,
+and then re-enable the dependent app</p>', ['incpages' => ['jQuery'], 'incmethod' => 'append']);

--- a/core/apps/SdmCoreOverview/SdmCoreOverview.php
+++ b/core/apps/SdmCoreOverview/SdmCoreOverview.php
@@ -14,7 +14,7 @@ if ($sdmassembler->sdmCoreDetermineRequestedPage() === 'SdmCoreOverview') {
      */
     function convertBytes($bytes, $decimals = 2)
     {
-        $unit = 'BKMGTP';
+        $unit = str_split('BKMGTP');
         $factor = floor((strlen($bytes) - 1) / 3);
         return sprintf("%.{$decimals}f", $bytes / pow(1024, $factor)) . formatUnitBySize($unit[$factor]);
     }

--- a/core/config/config.php
+++ b/core/config/config.php
@@ -4,15 +4,18 @@
  * This file defines constants for the Sdm Cms core.
  *
  * THESE SETTINGS SHOULD ONLY BE CHANGED IF YOU KNOW EXACTLY WHAT YOUR DOING AND WHAT THE CONSEQUENCES ARE!
- * Additionally do not add any constants to this file unless you are absolutely sure that you know what you are doing *
+ * Additionally do not add anything to this file unless you are absolutely sure that you know what you are doing.
  *
  * Modifying this file in any way will have unknown consequences for your SDM CMS site and also may introduce
  * unknown security risks, lead to data loss, and could permanently break your site. BETTER TO LEAVE THIS FILE ALONE!
  */
 
-
-/* CONSTANT for the sites Root directory */
+/**
+ * @constant string __SDM_ROOTDIR__ Site root directory.
+ */
 define('__SDM_ROOTDIR__', str_replace('/core/config', '', __DIR__));
 
-/* CONSTANT for the sites Includes directory */
+/**
+ * @constant string __SDM_INCDIR__ Site includes directory.
+ */
 define('__SDM_INCTDIR__', __SDM_ROOTDIR__ . '/core/includes');

--- a/core/config/defaultDataConfig.php
+++ b/core/config/defaultDataConfig.php
@@ -3,7 +3,31 @@
 /* Initialize default content */
 
 /* Homepage */
-$homepageMainContent = '<p>Welcome to your new SDM CMS powered site. To start adding content check out the <a href="' . $sdmGatekeeper->sdmCoreGetRootDirectoryUrl() . '/index.php?page=contentManager">content manager</a></p>';
+$homepageMainContent = '
+<p>Welcome to your new SDM CMS powered site. To start adding content check out the
+<a href="' . $sdmGatekeeper->sdmCoreGetRootDirectoryUrl() . '/index.php?page=contentManager">content manager</a></p>
+<p>The SDM CMS is a unique JSON driven CMS. Still in development, this CMS is designed to be easy to use, and easy to
+develop with. The user interface provided by the core apps makes it easy to build a site without writing a single
+line of code, and for the more hands on users, the SDM CMS can easily be customized and extended via the development
+of custom themes and user apps.</p>
+<p>The SDM CMS uses json to store site data, i.e., in place of a database a json file is used
+to store site data. Json was chosen because it is highly portable, is highly used,
+and because it is highly compatible with javascript, and other languages, and many
+languages like PHP have built in functions and methods for interacting with json.</p>
+<p>@todo: I am planning on developing a core app that will come packaged with the SDM CMS
+that will allow admin to switch to a database for storage. The supported
+databases at first will most likely be MySql and SQLite, also considering Mongo DB.</p>
+<p>Im currently working on the documentation for the SDM CMS, and as soon as
+I finish checking for typos and insuring clarity the documentation will
+be available.</p>
+<p>I built this CMS out of a love for coding, particularly in PHP. I had worked with other CMS\'s
+like Drupal, and WordPress, and wanted a simpler more portable CMS that was easier to grasp
+under the hood. I also wanted to get a better understanding of how a CMS works, and figured
+why not dive in and learn from experience.</p>
+<p>I am very passionate about this project, and will continue to develop and improve the SDM CMS.</p>
+<p>Thank you for trying out the Sdm Cms.</p>
+<p>Sevi Donnelly Foreman</p>
+';
 
 /* Sdm Cms Documentation */
 $sdmCmsDocumentationMainContent = '

--- a/core/includes/SdmAssembler.php
+++ b/core/includes/SdmAssembler.php
@@ -13,8 +13,15 @@ class SdmAssembler extends SdmNms
      * defined in enabled user and core app .as files, and in the current theme's .as file, into the
      * html header.
      *
-     * Note: App stylesheets, scripts, and meta tags will always be assembled first because
-     * app .as settings must take precedence over the current theme's .as file settings.
+     * Note: Header properties defined in app .as files will always be assembled first because
+     * app .as settings must take precedence over the current theme's .as file settings. The
+     * order app header properties are assembled relative to other apps depends on the order
+     * in which the apps were enabled. The most recent app to be enabled will have it's header
+     * properties assembled last. So if apps A and C were enabled before app B then app B's
+     * header properties will be assembled after apps A and app C have their header properties
+     * assembled. However, if app A and B and C were enabled at the same time then the order
+     * is alphabetical, so app B will have its header properties assembled after app A and
+     * before app C.
      *
      * @return string The html header for the page.
      *
@@ -39,7 +46,7 @@ class SdmAssembler extends SdmNms
 
     /**
      * Assembles the header properties defined in a .as file
-     * for all enabled apps that provide a .as file
+     * for all enabled apps that provide a .as file.
      *
      * @return string Html formatted string of link, script, and meta tags for any stylesheets, scripts, and meta
      * properties defined in any enabled apps .as file.
@@ -65,6 +72,8 @@ class SdmAssembler extends SdmNms
 
             /* Look in core apps for .as file. */
             $appScriptProps .= ($this->sdmAssemblerAssembleHeaderProperties('scripts', 'coreApp', $app) === false ? '' : $this->sdmAssemblerAssembleHeaderProperties('scripts', 'coreApp', $app));
+            $appScriptProps .= ($this->sdmAssemblerAssembleHeaderProperties('stylesheets', 'coreApp', $app) === false ? '' : $this->sdmAssemblerAssembleHeaderProperties('stylesheets', 'coreApp', $app));
+            $appScriptProps .= ($this->sdmAssemblerAssembleHeaderProperties('meta', 'coreApp', $app) === false ? '' : $this->sdmAssemblerAssembleHeaderProperties('meta', 'coreApp', $app));
 
         }
         return $appScriptProps;
@@ -75,10 +84,18 @@ class SdmAssembler extends SdmNms
      *
      * By default this method assembles header properties for the current theme.
      *
+     * i.e.,
+     *
+     *   // assembles header properties for current theme.
+     *   sdmAssemblerAssembleHeaderProperties('theme');
+     *
+     *   // assembles header properties for the core contentManager app.
+     *   sdmAssemblerAssembleHeaderProperties('theme', 'coreApp', 'contentManager');
+     *
      * @param string $targetProperty Property to read. (options: stylesheets, scripts, or meta)
      *
      * @param string $source The type of component to assemble header properties for. (options: theme, userApp,
-     *                       or coreApp). Defaults to theme.
+     *                       or coreApp).
      *
      *                       IMPORTANT: If $source is set then $sourceName must also be set.
      *
@@ -86,7 +103,8 @@ class SdmAssembler extends SdmNms
      *
      *                       IMPORTANT: $sourceName must be set if $source is set.
      *
-     * @return string Html formatted string of link script and meta tags for properties defined in specified $sourceName's .as file.
+     * @return string Html formatted string of link script and meta tags for properties defined in specified
+     *                $sourceName's .as file.
      *
      */
     private function sdmAssemblerAssembleHeaderProperties($targetProperty, $source = null, $sourceName = null)

--- a/core/includes/SdmAssembler.php
+++ b/core/includes/SdmAssembler.php
@@ -832,17 +832,18 @@ class SdmAssembler extends SdmNms
     }
 
     /**
-     * Returns The required closing HTML tags for the page.
+     * Returns the required closing html tags for the page.
+     *
      * @return string The required HTML closing tags as a string.
      */
     public function sdmAssemblerAssembleHtmlRequiredClosingTags()
     {
         return '
-    <!--This site was built using the SDM CMS content management system which was
-        designed and developed by Sevi Donnelly Foreman in the year 2014.-->
-    <!--To contact the developer of the SDM CMS write to sdmwebsdm@gmail.com.-->
-    <!--Note: Sevi is not necessarily the author of this site, he is just the
-        developer of Content Management System that is used to build/maintain this site.-->
+    <!-- This site was built using the SDM CMS content management system which was
+         designed and developed by Sevi Donnelly Foreman in the year 2014. -->
+    <!-- To contact the developer of the SDM CMS write to sdmwebsdm@gmail.com. -->
+    <!-- Note: Sevi is not necessarily the author of this site, he is just the
+         developer of the Content Management System that is used to build and maintain this site. -->
     </body>
     </html>
     ';
@@ -859,9 +860,16 @@ class SdmAssembler extends SdmNms
      */
     public function sdmAssemblerGetContentHtml($wrapper)
     {
+        /* Determine requested page. */
         $page = $this->sdmCoreDetermineRequestedPage();
+
+        /* Assemble the wrapper. */
         $wrapperAssembledContent = (isset($this->DataObject->content->$page->$wrapper) ? $this->DataObject->content->$page->$wrapper : '<!-- ' . $wrapper . ' placeholder -->');
+
+        /* Get any menus that belong to this wrapper. */
         $content = $this->sdmNmsGetWrapperMenusHtml($wrapper, $wrapperAssembledContent);
+
+        /* Return the assembled wrapper. */
         return $content;
     }
 

--- a/core/includes/SdmAssembler.php
+++ b/core/includes/SdmAssembler.php
@@ -623,7 +623,14 @@ class SdmAssembler extends SdmNms
      *
      *   'roles' :       Array of roles that have permission to view app output. Passing the special
      *                   value 'all' will give all users permission to view app output. Current options
-     *                   for roles are root, basicUser, and the special value all.
+     *                   for roles are root, basicUser, and the special value all. If an empty array is
+     *                   passed it will be assumed that no users can see this app output.
+     *
+     *                   // All users will have permission to view this app output. //
+     *                   sdmAssemblerIncorporateAppOutput($output, array('roles' => array('all')));
+     *
+     *                   // No users will have permission to view this app output because 'roles' is empty. //
+     *                   sdmAssemblerIncorporateAppOutput($output, array('roles' => array()));
      *
      *
      * @return bool True if output was incorporated, or false on failure.
@@ -693,49 +700,39 @@ class SdmAssembler extends SdmNms
      */
     final private function filterOptionsArray(&$options)
     {
-        /* OPTIONS ARRAY check| Review $options array values to insure they exist
-        in prep for checks that determine how app should be incorporated | If they
-        weren't passed in via the $options argument then they will be assigned a
-        default value and stored in the $options array */
-        // if $options['wrapper'] is not set
+        /* Review $options array values to insure they exist. If they don't
+        then they will be created and assigned a default value */
+
+        /* If $options['wrapper'] is not set create it with value 'main_content'. */
         if (!isset($options['wrapper'])) {
             $options['wrapper'] = 'main_content';
         }
-        // if incmethod was not passed to the $options array create it
+
+        /* If $options['incmethod'] is not set create it with value 'append'. */
         if (!isset($options['incmethod'])) {
             $options['incmethod'] = 'append';
         }
-        // if ingorepages array was not passed to the $options array create it
+
+        /* If $options['ignorepages'] was not set create it and assign an empty array as it's value. */
         if (!isset($options['ignorepages'])) {
             $options['ignorepages'] = [];
         }
-        // if incpages array was not passed to the $options array create it
+
+        /* If $options['incpages'] was not set create it and assign an array filled with all pages in
+         the DataObject and with the names of all enabled apps. */
         if (!isset($options['incpages'])) {
-            /* For security, we check to see if the incpages array was passed to the options array.
-             * If it was then leave it alone and use it as it is, if it wasn't then we assume the
-             * developer meant to incorporate into all pages so we create an incpages array that
-             * contains all the pages in core as well as any enabled apps so any app generated pages
-             * will also incorporate app output.
-             * Also note that if inpages is empty then it will be assumed the developer
-             * does NOT want to incorporate app output into any page.
-             * i.e.,
-             *   // app out put will NOT be incorporated into any pages because incpages is empty
-             *   sdmAssemblerIncorporateAppOutput($this->DataObject, $output, array('incpages' => array());
-             *   //app out put will be incorporated into all pages because incpages does not exist, and will
-             *     therefore be created and configured with pre-determined internal default values
-             *   sdmAssemblerIncorporateAppOutput($this->DataObject, $output);
-             *
-             */
             $pages = $this->sdmCoreDetermineAvailablePages();
             $enabledApps = json_decode(json_encode($this->sdmCoreDetermineEnabledApps()), true);
             $options['incpages'] = array_merge($pages, $enabledApps);
         }
-        /* If $options['roles'] is not set then we assume all users should see this app output and we add
-        the special 'all' value to the $options['roles'] array, if $options['roles'] is empty we assume
-        no users can see this app output.*/
+
+        /* If $options['roles'] is not set create it and assign an array containing the special 'all' value.
+         If $options['roles'] is empty it will be assumed that no users can see this app output. */
         if (!isset($options['roles'])) {
             $options['roles'] = ['all'];
         }
+
+        /* Return the filtered $options array. */
         return $options;
     }
 

--- a/core/includes/SdmAssembler.php
+++ b/core/includes/SdmAssembler.php
@@ -89,8 +89,11 @@ class SdmAssembler extends SdmNms
      *                formatted appropriately for html.
      *
      */
-    private function sdmAssemblerAssembleHeaderProperties($targetProperty, $source = null, $sourceName = null)
+    private function sdmAssemblerAssembleHeaderProperties($targetProperty, $source = 'theme', $sourceName = null)
     {
+        if ($sourceName === null) {
+            $sourceName = $this->sdmCoreDetermineCurrentTheme();
+        }
         /* Initialize $html var. */
         $html = $this->sdmAssemblerAssembleInitialHeaderPropertyHtml($targetProperty, $source, $sourceName);
 
@@ -220,23 +223,7 @@ class SdmAssembler extends SdmNms
      */
     private function sdmAssemblerGetAsProperty($property, $source = null, $sourceName = null)
     {
-        switch ($source) {
-            case 'theme':
-                /* Read .as file into an array. */
-                $asFileArray = $this->sdmAssemblerLoadAsFile($this->sdmCoreGetThemesDirectoryPath(), $sourceName);
-                break;
-            case 'userApp':
-                /* Read .as file into an array. */
-                $asFileArray = $this->sdmAssemblerLoadAsFile($this->sdmCoreGetUserAppDirectoryPath(), $sourceName);
-                break;
-            case 'coreApp':
-                /* Read .as file into an array. */
-                $asFileArray = $this->sdmAssemblerLoadAsFile($this->sdmCoreGetCoreAppDirectoryPath(), $sourceName);
-                break;
-            default: /* Defaults to reading the current theme's .as file. */
-                $asFileArray = $this->sdmAssemblerLoadAsFile($this->sdmCoreGetThemesDirectoryPath(), $this->sdmCoreDetermineCurrentTheme());
-                break;
-        }
+        $asFileArray = $this->sdmAssemblerLoadAsFile($source, $sourceName);
         $properties = $this->sdmAssemblerRetrieveAsPropertyValues($property, $asFileArray);
         return ($asFileArray === false || isset($properties) !== true ? false : $properties);
     }
@@ -244,7 +231,10 @@ class SdmAssembler extends SdmNms
     /***
      * Load a .as file from a specific path and read it into an array.
      *
-     * @param string $path The path where the .as file should exist.
+     * @param string $source The type of component. (options: theme, userApp,
+     *                       or coreApp). Defaults to theme.
+     *
+     *                       IMPORTANT: If $source is set then $sourceName must also be set.
      *
      * @param string $sourceName The name of the relevant theme or app.
      *
@@ -253,8 +243,22 @@ class SdmAssembler extends SdmNms
      * @return array|bool An array representing the data in the .as file, or false on failure.
      *
      */
-    final private function sdmAssemblerLoadAsFile($path, $sourceName)
+    final private function sdmAssemblerLoadAsFile($source, $sourceName)
     {
+        switch ($source) {
+            case 'theme':
+                $path = $this->sdmCoreGetThemesDirectoryPath();
+                break;
+            case 'userApp':
+                $path = $this->sdmCoreGetUserAppDirectoryPath();
+                break;
+            case 'coreApp':
+                $path = $this->sdmCoreGetCoreAppDirectoryPath();
+                break;
+            default:
+                $path = $this->sdmCoreGetCurrentThemeDirectoryPath();
+                break;
+        }
         /* Build file path to our .as file. */
         $filePath = $path . '/' . $sourceName . '/' . $sourceName . '.as';
         return (file_exists($filePath) === true ? file($filePath) : false);

--- a/core/includes/SdmAssembler.php
+++ b/core/includes/SdmAssembler.php
@@ -5,8 +5,6 @@
  * It is also responsible for incorporating output from core and user apps into
  * a page.
  *
- * @author foremase
- *
  */
 class SdmAssembler extends SdmNms
 {
@@ -15,9 +13,8 @@ class SdmAssembler extends SdmNms
      * defined in enabled user and core app .as files, and in the current theme's .as file, into the
      * html header.
      *
-     * Note: App stylesheets, scripts, and meta tags will always be incorporated first since the
-     * purpose of apps is to extend, and we want to insure their .as settings take precedence over
-     * the current theme's .as file settings.
+     * Note: App stylesheets, scripts, and meta tags will always be assembled first because
+     * app .as settings must take precedence over the current theme's .as file settings.
      *
      * @return string The HTML header for the page.
      *
@@ -44,8 +41,8 @@ class SdmAssembler extends SdmNms
      * Assembles the link, script, and meta tags that load the stylesheets scripts and meta tags
      * for all enabled apps that provide a .as file
      *
-     * NOTE: At the moment apps are only allowed to define the scripts property in their .as files.
-     * Apps will eventually be able to define the meta and stylesheet properties.
+     * NOTE: At the moment only the scripts property is read from an app's .as file. In the future
+     * stylesheets and meta will also be read from an app's .as file.
      *
      * @return string String of link, script, and meta tags for any stylesheets, scripts, and meta properties
      * defined in any enabled apps .as file.
@@ -55,7 +52,7 @@ class SdmAssembler extends SdmNms
     {
         /** Assemble header properties for enabled core and user apps. **/
 
-        /* Initialize $appScriptProps var */
+        /* Initialize $appScriptProps var. */
         $appScriptProps = '';
 
         /* Loop through enabled apps. */
@@ -77,15 +74,16 @@ class SdmAssembler extends SdmNms
     /**
      * Assembles link script and meta tags for header properties defined in a specific theme or app's .as file.
      *
-     * @param $targetProperty string Property to read. (options: stylesheets, scripts, or meta)
+     * @param string $targetProperty Property to read. (options: stylesheets, scripts, or meta)
      *
-     * @param $source string Determines where the .as file should be loaded from. (options: theme, userApp, or coreApp).
-     *                       Defaults to current theme.
+     * @param string $source The type of component to assemble header properties for. (options: theme, userApp,
+     *                       or coreApp). Defaults to theme.
      *
      *                       IMPORTANT: If $source is set then $sourceName must also be set.
      *
      * @param string $sourceName The name of the theme or app whose .as file we are reading header properties from.
-     *                           $sourceName must be set if $source is set.
+     *
+     *                       IMPORTANT: $sourceName must be set if $source is set.
      *
      * @return string String of link script and meta tags for properties defined in specified $sourceName's .as file
      *                formatted appropriately for html.
@@ -101,9 +99,7 @@ class SdmAssembler extends SdmNms
          load the .as file properties failed. */
         $initHtml = $html;
 
-        /* Determine path to resource directory based on $source and $sourceName.
-        i.e., directory where stylesheets and scripts defined in .as file are
-        located. Defaults to current themes root directory. */
+        /* Determine path to resource directory based on $source and $sourceName. */
         $path = $this->sdmAssemblerDetermineAsFilePath($source, $sourceName);
 
         /* Attempt to read header properties from .as file if it exists. If no $source is specified
@@ -154,15 +150,16 @@ class SdmAssembler extends SdmNms
     /**
      * Assembles the initial header property html.
      *
-     * @param $targetProperty string Property to read. (options: stylesheets, scripts, or meta)
+     * @param string $targetProperty The target property. (options: stylesheets, scripts, or meta)
      *
-     * @param $source string Determines where the .as file should be loaded from. (options: theme, userApp, or coreApp).
-     *                       Defaults to current theme.
+     * @param string $source The type of component. (options: theme, userApp,
+     *                       or coreApp). Defaults to theme.
      *
      *                       IMPORTANT: If $source is set then $sourceName must also be set.
      *
-     * @param string $sourceName The name of the theme or app whose .as file we are reading header properties from.
-     *                           $sourceName must be set if $source is set.
+     * @param string $sourceName The name of the relevant theme or app.
+     *
+     *                       IMPORTANT: $sourceName must be set if $source is set.
      *
      * @return string Initial header property html.
      */
@@ -174,11 +171,13 @@ class SdmAssembler extends SdmNms
     /**
      * Determines path to .as file for a specified app or theme.
      *
-     * @param string $source Determines where the .as file should be loaded from. (options: theme, userApp, or coreApp).
-     *                Defaults to current theme.
+     * @param string $source The type of component (options: theme, userApp, or coreApp). Defaults to theme.
      *
-     * @param string $sourceName The name of the theme or app whose .as file we are reading header properties from.
-     *                    $sourceName must be set if $source is set.
+     *                    IMPORTANT: If $source is set then $sourceName must also be set.
+     *
+     * @param string $sourceName The name of the relevant theme or app.
+     *
+     *                    IMPORTANT: $sourceName must be set if $source is set.
      *
      * @return null|string The path to the .as file for the specified app or theme. Returns null on failure.
      *
@@ -189,48 +188,34 @@ class SdmAssembler extends SdmNms
     }
 
     /**
-     * Returns an array of values for a specified property from a
+     * Returns an array of values for a specified property defined in a
      * specified theme or app's .as file.
      *
-     * @param string $property The property whose values should be returned in an array. (e.g., 'stylesheets')
+     * NOTE: If $source is not set then the current themes .as file will be read.
      *
-     * @param string $source Determines where the .as file should be loaded from. Either
-     *                       theme, userApp, or coreApp.
+     * @param string $property The property whose values should be returned.
+     *                       (options: stylesheets, scripts, meta)
      *
-     *                       NOTE: If source is not set then it will be assumed that the $property
-     *                       values should be read from the current theme's .as file as this was the original
-     *                       purpose of this method. It evolved to target specific .as files from specific
-     *                       apps so developers could have their themes and apps incorporate stylesheets,
-     *                       scripts, and add meta tags to the header of the page by providing a .as file.
-     *                       This method can also be used by developers in apps and themes to target a specific
-     *                       .as file and read it's properties.
+     * @param string $source The type of component (options: theme, userApp, or coreApp). Defaults to theme.
      *
-     *                       e.g.,
+     *                    IMPORTANT: If $source is set then $sourceName must also be set.
      *
-     *                         sdmAssemblerGetAsProperty('script', 'userApp', 'jQuery');
+     * @param string $sourceName The name of the relevant theme or app.
      *
-     *                       Returns an array of scripts defined in
-     *                       the jQuery user app's .as file if it exists,
-     *                       or false on failure.
-     *
-     *                       IMPORTANT: If $source is set then $sourceName must also be set.
-     *
-     *                       sdmAssemblerGetAsProperty('script', 'userApp')
-     *
-     *                       The code above fails because no user app is specified, i.e., the $sourceName
-     *                       is not specified.
-     *
-     * @param string $sourceName The name of the theme or app whose .as file we are reading .as property values from.
+     *                       IMPORTANT: $sourceName must be set if $source is set.
      *
      * @return array|bool An array of values for the specified $property, or false on failure.
      *
      *               Note: false will be returned if
      *               any of the following are true:
      *
-     *               * If .as file does not exist.
-     *               * If property is not set in .as file.
-     *               * If listed but not defined, i.e., property is set in .as file but does not have any values.
-     *               * If the method failed to get the property values far any other reason.
+     *               - If .as file does not exist.
+     *
+     *               - If property is not set in .as file.
+     *
+     *               - If property listed in .as file but not defined.
+     *
+     *               - If the method failed to get the property values far any other reason.
      *
      */
     private function sdmAssemblerGetAsProperty($property, $source = null, $sourceName = null)
@@ -256,14 +241,17 @@ class SdmAssembler extends SdmNms
         return ($asFileArray === false || isset($properties) !== true ? false : $properties);
     }
 
-    /**
+    /***
      * Load a .as file from a specific path and read it into an array.
+     *
      * @param string $path The path where the .as file should exist.
-     * @param string $sourceName The name associated with the .as file. (Do not include .as extension.)
-     *                    i.e., Load helloWorld user app's .as file:
-     *                          GOOD CALL: loadAsFile('/path/to/userApps', 'helloWorld'); // succeeds
-     *                          BAD CALL: loadAsFile('/path/to/userApps', 'helloWorld.as'); // fails
+     *
+     * @param string $sourceName The name of the relevant theme or app.
+     *
+     *                       IMPORTANT: $sourceName must be set if $source is set.
+     *
      * @return array|bool An array representing the data in the .as file, or false on failure.
+     *
      */
     final private function sdmAssemblerLoadAsFile($path, $sourceName)
     {
@@ -275,19 +263,23 @@ class SdmAssembler extends SdmNms
     /**
      * Retrieves a specified properties values from the array returned
      * by sdmAssemblerLoadAsFile(). This method is for internal use only.
+     *
      * @param string $property The property to retrieve values from.
+     *
      * @param array|bool $asFileArray The return value from call to sdmAssemblerLoadAsFile().
      *                                This will be either an array or the boolean value false.
+     *
      * @return array|bool Array of property values for the specified property, or false on failure.
+     *
      */
     final private function sdmAssemblerRetrieveAsPropertyValues($property, $asFileArray)
     {
         if ($asFileArray !== false) {
             /* Loop through array. i.e., loop through each line of the .as file. */
             foreach ($asFileArray as $line) {
-                /* check if current $line is for $property */
+                /* Check if current $line matches $property. */
                 if (strstr($line, '=', true) === $property) {
-                    /* store property values in an array */
+                    /* Store property values in an array. */
                     $properties = explode(',', $this->sdmCoreStrSlice($line, '=', ';'));
                     return $properties;
                 }
@@ -438,13 +430,13 @@ class SdmAssembler extends SdmNms
     }
 
     /**
-     * <p style="font-size:9px;">Incorporates app output into the page.</p>
-     * <p style="font-size:9px;">This method is intended for use by CORE and User apps. It provides
+     * Incorporates app output into the page.
+     * This method is intended for use by CORE and User apps. It provides
      * a simple method for incorporating an app's output into the page. It is
-     * ok to call this method multiple times within an app.</p>
-     * <p style="font-size:9px;">If provided, the $options array is used to specify how the app's output
-     * is to be incorporated.</p>
-     * <p style="font-size:9px;"><b>NOTE</b>: If the requested page (determined internally) does not exist
+     * ok to call this method multiple times within an app.
+     * If provided, the $options array is used to specify how the app's output
+     * is to be incorporated.
+     * Note: If the requested page (determined internally) does not exist
      * in CORE, as an enabled app, or in the $options array's 'incpages' array then the dataObject will not be modified
      * and the apps output will not be incorporated. This is for security, and prevents requests to
      * non-existent pages from successfully taking user to a dynamically generated page.
@@ -453,51 +445,51 @@ class SdmAssembler extends SdmNms
      * So, if the requested page does not exist in CORE, it must at least exist as a on of the
      * pages specified in the $options array's 'incpages' array. Without this check we could pass anything
      * to the page argument in the url and the SDM CMS would generate a page for it.
-     * <br /><br />i.e, http://example.com/index.php?page=NonExistentPage would work if we did not check for it in CORE
-     * and in the 'incpages' array</p>
-     * @param string $output <p style="font-size:9px;"p>A plain text or HTML string to be used as the apps output.</p>
-     * @param array $options (optional) <p style="font-size:9px;">Array of options that determine how an app's
+     * i.e, http://example.com/index.php?page=NonExistentPage would work if we did not check for it in CORE
+     * and in the 'incpages' array
+     *
+     * @param string $output A plain text or HTML string to be used as the apps output.
+     *
+     * @param array $options (optional) Array of options that determine how an app's
      * output is incorporated. If not specified, then the app will be incorporated into
      * all pages and will be assigned to the 'main_content' wrapper that is part of, and,
-     * required by SDM CORE.<br />
-     * <br /><b>Overview of $options ARRAY:</b>
-     * <ul style="font-size:9px;">
-     *   <li>'wrapper' : The content wrapper the app is to be incorporated into.
-     *                   If not specified then 'main_content' is assumed</li>
-     *   <li>'incmethod' : Determines how app output should be incorporated.<br />
-     *                     Options for 'incmethod' are <b><i>append</i></b>,
-     *                     <b><i>prepend</i></b>, and <b><i>overwrite</i></b>. Defaults to <b>append</b>.
-     *   </li>
-     *   <li>'incpages' : Array of pages to incorporate the app output into. You can also pass in the name
+     * required by SDM CORE.
+     * Overview of $options ARRAY:
+     *
+     *   'wrapper' : The content wrapper the app is to be incorporated into.
+     *                   If not specified then 'main_content' is assumed.
+     *   'incmethod' : Determines how app output should be incorporated.
+     *                     Options for 'incmethod' are append,
+     *                     prepend, and overwrite. Defaults to append.
+     *   'incpages' : Array of pages to incorporate the app output into. You can also pass in the name
      *                    of an app and then any page that app generates will also incorporate the app out put
      *                    as long as the page the app generates shares the same name as the app itself.
      *                    (i.e. if you incpages has an item ExampleApp then the page ExampleApp
      *                          will incorporate app output even if the page ExampleApp does not
      *                          exist in CORE.)
-     *  <br />Note: If incpages is not set then it is assumed that all pages
+     *   Note: If incpages is not set then it is assumed that all pages
      *              are to incorporate app output. If an empty array is passed
      *              then NO pages will incorporate app output.
      *              (i.e., passing an empty array is basically the same as passing
      *                     in an ignorepages array that contains the names of all pages
-     *                     and enabled apps.</li>
-     *   <li>'ignorepages' : Array of pages NOT to incorporate the app output into. This
+     *                     and enabled apps.
+     *   'ignorepages' : Array of pages NOT to incorporate the app output into. This
      *                       array can include the names of Apps that should NOT incorporate
      *                       this output into pages that they generate.
-     *                      <br />(i.e, if an ExampleApp exists in ignorePages then any
+     *                      (i.e, if an ExampleApp exists in ignorePages then any
      *                             page generated by the ExampleApp app will not incorporate
-     *                             the app output)
-     *   </li>
-     *   <li>'roles' : Array of roles that can view this output.</li>
-     * </ul>
-     * <b>NOTE: If a page is found in both the 'incpages' and 'ignorepages' arrays then
+     *                             the app output).
+     *   'roles' : Array of roles that can view this output.
+     *
+     * NOTE: If a page is found in both the 'incpages' and 'ignorepages' arrays then
      *          the app output will be ignored on that page. This is for security, best to assume
      *          in such a case that the developer meant to ignore a page if the developer passes
-     *          a page to both the 'incpages' and 'ignorepages' arrays.</b>
-     * </p>
-     * @return object <p style="font-size:9px;">The DataObject with or without app modifications incorporated.
+     *          a page to both the 'incpages' and 'ignorepages' arrays.
+     *
+     * @return object The DataObject with or without app modifications incorporated.
      * The DataObject may be returned without modification for a number of reasons including the user not
      * having permission to view the app, the requested page being found in the options:ignorepages array or
-     * not being found in the options:incpages array, or a number of other factors.</p>
+     * not being found in the options:incpages array, or a number of other factors.
      */
     public function sdmAssemblerIncorporateAppOutput($output, array $options = [])
     {

--- a/core/includes/SdmAssembler.php
+++ b/core/includes/SdmAssembler.php
@@ -695,8 +695,7 @@ class SdmAssembler extends SdmNms
      * @param array $options The options array as it was passed to sdmAssemblerIncorporateAppOutput().
      *
      * @return array The filtered options array. This method handles the options array by reference so there is
-     * no need to assign it's return value to a var in sdmAssemblerIncorporateAppOutput(). Just call:
-     * $this->filterOptionsArray($options) and the options array will be filtered.
+     * no need to assign it's return value to a variable.
      */
     final private function filterOptionsArray(&$options)
     {
@@ -715,7 +714,7 @@ class SdmAssembler extends SdmNms
 
         /* If $options['ignorepages'] was not set create it and assign an empty array as it's value. */
         if (!isset($options['ignorepages'])) {
-            $options['ignorepages'] = [];
+            $options['ignorepages'] = array();
         }
 
         /* If $options['incpages'] was not set create it and assign an array filled with all pages in
@@ -729,7 +728,7 @@ class SdmAssembler extends SdmNms
         /* If $options['roles'] is not set create it and assign an array containing the special 'all' value.
          If $options['roles'] is empty it will be assumed that no users can see this app output. */
         if (!isset($options['roles'])) {
-            $options['roles'] = ['all'];
+            $options['roles'] = array('all');
         }
 
         /* Return the filtered $options array. */
@@ -738,8 +737,14 @@ class SdmAssembler extends SdmNms
 
     /**
      * Determines if a user has permission to use app based on
-     * weather or not the current user role is found in the
-     * options array provided by the app.
+     * weather or not the current user's role is found in the
+     * $options['roles'] array.
+     *
+     * If the special value 'all' is found in the $options['roles'] array
+     * then all users will be given permission to use the app.
+     *
+     * This method should only be called internally by sdmAssemblerIncorporateAppOutput(), it is not
+     * designed for use by other components.
      *
      * @param array $options The options array provided by the app.
      *
@@ -747,9 +752,8 @@ class SdmAssembler extends SdmNms
      */
     final private function sdmAssemblerUserCanUseApp($options)
     {
-        /* first we check if app output is restricted to certain roles. if it is we check that
-        current user role matches one of the valid roles for the app. If the special 'all' role
-        is in the $options['roles'] array then all users see the app output */
+        /* Return true if current user's role is found in the $options['roles'] array, or if the special 'all'
+         value is found in the $options['roles'] array, otherwise return false. */
         return (in_array($this->sdmGatekeeperDetermineUserRole(), $options['roles'], true) || in_array('all', $options['roles'], true) ? true : false);
     }
 
@@ -809,8 +813,8 @@ class SdmAssembler extends SdmNms
      * no bad chars are included and that the encoding is UTF-8.
      *
      * In order to insure html tags are interpreted as html we need to reverse some of the filtering that was done when
-     * the page was created by the SdmCms() class. @see SdmCms::sdmCmsUpdateContent() for
-     * more information on how data is filtered on page creation.
+     * the page was created by the SdmCms() class. @see SdmCms::sdmCmsUpdateContent() for more information on how data
+     * is filtered on page creation.
      *
      * This method should only be used internally by the SdmAssembler and should be kept private.
      *

--- a/core/includes/SdmAssembler.php
+++ b/core/includes/SdmAssembler.php
@@ -5,6 +5,8 @@
  * It is also responsible for incorporating output from core and user apps into
  * a page.
  *
+ * @author Sevi Donnelly Foreman
+ *
  */
 class SdmAssembler extends SdmNms
 {
@@ -363,13 +365,13 @@ class SdmAssembler extends SdmNms
 
         /* Assemble internal meta structures */
         foreach ($metaData as $data) {
-            /* Remove '[' and ']' from each piece of meta $data*/
+            /* Remove '[' and ']' from each piece of meta $data. */
             $data = str_replace(['[', ']'], '', $data);
-            /* Replace ',' with '"' in each piece of meta $data*/
+            /* Replace ',' with '"' in each piece of meta $data. */
             $data = str_replace(',', '"', $data);
-            /* Replace ':' with '=' in each piece of meta $data*/
+            /* Replace ':' with '=' in each piece of meta $data. */
             $data = str_replace(':', '="', $data);
-            /* Replace '|' with ' ' in each piece of meta $data*/
+            /* Replace '|' with ' ' in each piece of meta $data. */
             $data = str_replace('|', ' ', $data) . '"';
             /* Add extracted meta $data to $meta array. */
             $meta[] = $data;
@@ -447,10 +449,10 @@ class SdmAssembler extends SdmNms
         /* Load and assemble enabled apps. */
         $this->sdmAssemblerLoadApps();
 
-        /* Cast $sdmAssemblerDataObject->content->$requestedPage to an array so PHP's empty() can be used to test if there is any
-           content to be assembled. empty() works better then isset() because the DataObject's content object may exist
-           with no properties which would cause an isset() check to return true even if there isn't any content to be
-           assembled. */
+        /* Cast $sdmAssemblerDataObject->content->$requestedPage to an array so PHP's empty() can be used
+           to test if there is any content to be assembled. empty() works better then isset() because the
+           DataObject's content object may exist with no properties which would cause an isset() check to
+           return true even if there isn't any content to be assembled. */
         $requestedPageContent = (array)$this->DataObject->content->$requestedPage;
 
         /* Make sure page exists in DataObject or as a dynamically generated app page by checking
@@ -856,7 +858,6 @@ class SdmAssembler extends SdmNms
      * @param string $wrapper The wrapper to assemble html for.
      *
      * @return string String of html for specified wrapper.
-     *
      */
     public function sdmAssemblerGetContentHtml($wrapper)
     {

--- a/core/includes/SdmAssembler.php
+++ b/core/includes/SdmAssembler.php
@@ -41,9 +41,6 @@ class SdmAssembler extends SdmNms
      * Assembles the header properties defined in a .as file
      * for all enabled apps that provide a .as file
      *
-     * NOTE: At the moment only the scripts property is read from an app's .as file. In the future
-     * stylesheets and meta will also be read from an app's .as file.
-     *
      * @return string Html formatted string of link, script, and meta tags for any stylesheets, scripts, and meta
      * properties defined in any enabled apps .as file.
      *
@@ -63,6 +60,8 @@ class SdmAssembler extends SdmNms
 
             /* Look in user apps for .as file. */
             $appScriptProps .= ($this->sdmAssemblerAssembleHeaderProperties('scripts', 'userApp', $app) === false ? '' : $this->sdmAssemblerAssembleHeaderProperties('scripts', 'userApp', $app));
+            $appScriptProps .= ($this->sdmAssemblerAssembleHeaderProperties('stylesheets', 'userApp', $app) === false ? '' : $this->sdmAssemblerAssembleHeaderProperties('stylesheets', 'userApp', $app));
+            $appScriptProps .= ($this->sdmAssemblerAssembleHeaderProperties('meta', 'userApp', $app) === false ? '' : $this->sdmAssemblerAssembleHeaderProperties('meta', 'userApp', $app));
 
             /* Look in core apps for .as file. */
             $appScriptProps .= ($this->sdmAssemblerAssembleHeaderProperties('scripts', 'coreApp', $app) === false ? '' : $this->sdmAssemblerAssembleHeaderProperties('scripts', 'coreApp', $app));

--- a/core/includes/SdmAssembler.php
+++ b/core/includes/SdmAssembler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * The SdmAssembler() is responsible for loading and assembling page content.
+ * The SdmAssembler() is responsible for loading and assembling a page.
  * It is also responsible for incorporating output from core and user apps into
  * a page.
  *
@@ -16,7 +16,7 @@ class SdmAssembler extends SdmNms
      * Note: App stylesheets, scripts, and meta tags will always be assembled first because
      * app .as settings must take precedence over the current theme's .as file settings.
      *
-     * @return string The HTML header for the page.
+     * @return string The html header for the page.
      *
      */
     public function sdmAssemblerAssembleHtmlHeader()
@@ -38,14 +38,14 @@ class SdmAssembler extends SdmNms
     }
 
     /**
-     * Assembles the link, script, and meta tags that load the stylesheets scripts and meta tags
+     * Assembles the header properties defined in a .as file
      * for all enabled apps that provide a .as file
      *
      * NOTE: At the moment only the scripts property is read from an app's .as file. In the future
      * stylesheets and meta will also be read from an app's .as file.
      *
-     * @return string String of link, script, and meta tags for any stylesheets, scripts, and meta properties
-     * defined in any enabled apps .as file.
+     * @return string Html formatted string of link, script, and meta tags for any stylesheets, scripts, and meta
+     * properties defined in any enabled apps .as file.
      *
      */
     final private function sdmAssemblerAssembleEnabledAppProps()
@@ -74,6 +74,8 @@ class SdmAssembler extends SdmNms
     /**
      * Assembles link script and meta tags for header properties defined in a specific theme or app's .as file.
      *
+     * By default this method assembles header properties for the current theme.
+     *
      * @param string $targetProperty Property to read. (options: stylesheets, scripts, or meta)
      *
      * @param string $source The type of component to assemble header properties for. (options: theme, userApp,
@@ -85,19 +87,14 @@ class SdmAssembler extends SdmNms
      *
      *                       IMPORTANT: $sourceName must be set if $source is set.
      *
-     * @return string String of link script and meta tags for properties defined in specified $sourceName's .as file
-     *                formatted appropriately for html.
+     * @return string Html formatted string of link script and meta tags for properties defined in specified $sourceName's .as file.
      *
      */
-    private function sdmAssemblerAssembleHeaderProperties($targetProperty, $source = 'theme', $sourceName = null)
+    private function sdmAssemblerAssembleHeaderProperties($targetProperty, $source = null, $sourceName = null)
     {
-        if ($sourceName === null) {
-            $sourceName = $this->sdmCoreDetermineCurrentTheme();
-        }
         /* Initialize $html var. */
         $html = $this->sdmAssemblerAssembleInitialHeaderPropertyHtml($targetProperty, $source, $sourceName);
-
-        /* Store initial $html value so we can perform a check later to see if anything was appended
+        /* Store initial $html value so a check can be performed later to see if anything was appended
          to $html, if nothing was appended to $html by the end of this method then the attempt to
          load the .as file properties failed. */
         $initHtml = $html;
@@ -114,7 +111,7 @@ class SdmAssembler extends SdmNms
 
         /* Make sure $properties array is not false and is not empty. */
         if ($properties !== false && !empty($properties) === true) {
-            /* Begin assembling  link script and meta tags for each of our header $properties. */
+            /* Begin assembling  link script and meta tags for each of the header $properties. */
             foreach ($properties as $property) {
                 /* Only assemble header property html if current $property value does not exist
                  in our $badValues array */
@@ -174,7 +171,7 @@ class SdmAssembler extends SdmNms
     /**
      * Determines path to .as file for a specified app or theme.
      *
-     * @param string $source The type of component (options: theme, userApp, or coreApp). Defaults to theme.
+     * @param string $source The type of component (options: theme, userApp, or coreApp).
      *
      *                    IMPORTANT: If $source is set then $sourceName must also be set.
      *
@@ -196,8 +193,7 @@ class SdmAssembler extends SdmNms
      *
      * NOTE: If $source is not set then the current themes .as file will be read.
      *
-     * @param string $property The property whose values should be returned.
-     *                       (options: stylesheets, scripts, meta)
+     * @param string $property The property whose values should be returned. (options: stylesheets, scripts, meta)
      *
      * @param string $source The type of component (options: theme, userApp, or coreApp). Defaults to theme.
      *
@@ -229,14 +225,16 @@ class SdmAssembler extends SdmNms
     }
 
     /***
-     * Load a .as file from a specific path and read it into an array.
+     * Load a .as file from a specific path and read it into an array. BY DEFAULT THIS METHDO DEFAULTS
+     * TO THE CURRENT THEME.
      *
      * @param string $source The type of component. (options: theme, userApp,
      *                       or coreApp). Defaults to theme.
      *
      *                       IMPORTANT: If $source is set then $sourceName must also be set.
      *
-     * @param string $sourceName The name of the relevant theme or app.
+     * @param string $sourceName The name of the relevant theme or app. Defaults to
+     *                           name of current theme.
      *
      *                       IMPORTANT: $sourceName must be set if $source is set.
      *
@@ -245,6 +243,10 @@ class SdmAssembler extends SdmNms
      */
     final private function sdmAssemblerLoadAsFile($source, $sourceName)
     {
+        /* If $sourceName is not defined default to current theme. */
+        if ($sourceName === null) {
+            $sourceName = $this->sdmCoreDetermineCurrentTheme();
+        }
         switch ($source) {
             case 'theme':
                 $path = $this->sdmCoreGetThemesDirectoryPath();
@@ -256,7 +258,7 @@ class SdmAssembler extends SdmNms
                 $path = $this->sdmCoreGetCoreAppDirectoryPath();
                 break;
             default:
-                $path = $this->sdmCoreGetCurrentThemeDirectoryPath();
+                $path = str_replace('/' . $sourceName, '', $this->sdmCoreGetCurrentThemeDirectoryPath());
                 break;
         }
         /* Build file path to our .as file. */

--- a/core/includes/SdmCms.php
+++ b/core/includes/SdmCms.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * The <b>SdmCms</b> is responsible for provideing the components necessary for
+ * The SdmCms is responsible for providing the components necessary for
  * content management.
  *
  * @author Sevi Donnelly Foreman
@@ -35,37 +35,52 @@ class SdmCms extends SdmCore
     {
         /* Load the entire data object */
         $dataObject = $this->sdmCoreLoadDataObject(false);
+
         /* Filter $html to insure encoding is UTF-8. */
         $filteredHtml = iconv("UTF-8", "UTF-8//IGNORE", $html);
         $filteredHtml2 = iconv("UTF-8", "ISO-8859-1//IGNORE", $filteredHtml);
         $filteredHtml3 = iconv("ISO-8859-1", "UTF-8", $filteredHtml2);
         $utf8Html = utf8_encode(trim($filteredHtml3));
+
         /* If the page does not already exist in the DataObject create a placeholder object for it. */
         if (!isset($dataObject->content->$page) === true) {
             $dataObject->content->$page = new stdClass();
         }
+
         /* Convert all applicable characters in $html to HTML entities. */
         $dataObject->content->$page->$wrapper = htmlentities($utf8Html, ENT_SUBSTITUTE | ENT_DISALLOWED | ENT_HTML5, 'UTF-8');
+
         /* Encode the updated dataObject as json to prepare for storage. */
         $data = json_encode($dataObject);
+
         /* Store the updates. */
         $update = file_put_contents($this->sdmCoreGetDataDirectoryPath() . '/data.json', $data, LOCK_EX);
+
         /* Determine weather the update succeeded or failed.*/
         $status = ($update < 0 || $update !== false ? true : false);
+
+        /**/
         return $status;
     }
 
     /**
-     * <p>Determines available content wrappers for current theme by looking in the <i>current theme's</i> page.php file.</p>
-     * @return array An array formated key => value where key is formated for display, and value is formated to be <b>code-safe</b>
-     * <p>i.e. the requried "main_content" wrapper would be returned in an array formated as follows<br/><br/>
-     * <b>array("Main Content" => 'main_content')</b></p>
+     * Determines available content wrappers for current theme by looking in the current theme's page.php file.
+     *
+     * @return array An array formatted key => value where key is formatted for display, and value is formatted to be
+     * code-safe.
+     *
+     * i.e. the 'main_content' wrapper would be returned in an array formatted as follows:
+     *
+     * array("Main Content" => 'main_content')
      */
     public function sdmCmsDetermineAvailableWrappers()
     {
         $html = file_get_contents($this->sdmCoreGetCurrentThemeDirectoryPath() . '/page.php');
         $dom = new DOMDocument();
-        // for now we are surpressing any errors thrown by loadHTML() because it complains when malformed xml and html is loaded, and the errors were clogging up the error log during other development branches. Howver it is very important that a fix is found for this issue as it could lead to unknown bugs.
+        /* For now we are suppressing any errors thrown by loadHTML() because it complains
+         when malformed xml and html is loaded, and the errors were clogging up the error
+         log during other development branches. However it is very important that a fix is
+         found for this issue as it could lead to unknown bugs. */
         @$dom->loadHTML($html);
         $xpath = new DOMXPath($dom);
         $tags = $xpath->query('//div[@id]');
@@ -79,14 +94,18 @@ class SdmCms extends SdmCore
     }
 
     /**
-     * <p>Loads a specific piece of content.</p>
-     * @param string $page <p>The page we want to load content from.</p>
-     * @param string $contentWrapper <p>The content wrapper we want to load content from.</p>
-     * @return string <p>The string of html for this $contentWrapper.</p>
+     * Loads a specific piece of content.
+     *
+     * @param string $page The name of the page whose content we want to load. Defaults to 'homepage'.
+     *
+     * @param string $contentWrapper The name of the content wrapper we want to load content from. Defaults
+     *                               to 'main_content'
+     *
+     * @return string String of html for the $contentWrapper.
      */
     public function sdmCmsLoadSpecificContent($page = 'homepage', $contentWrapper = 'main_content')
     {
-        // load our json data from data.json and convert into an array
+        /* load our json data from data.json and convert into an array */
         $data = json_decode(file_get_contents($this->sdmCoreGetCoreDirectoryPath() . '/sdm/data.json'), true);
         return $data['content'][$page][$contentWrapper]; // @TODO : Use object notation instead of array notation
     }

--- a/core/includes/SdmCms.php
+++ b/core/includes/SdmCms.php
@@ -106,8 +106,8 @@ class SdmCms extends SdmCore
     public function sdmCmsLoadSpecificContent($page = 'homepage', $contentWrapper = 'main_content')
     {
         /* load our json data from data.json and convert into an array */
-        $data = json_decode(file_get_contents($this->sdmCoreGetCoreDirectoryPath() . '/sdm/data.json'), true);
-        return $data['content'][$page][$contentWrapper]; // @TODO : Use object notation instead of array notation
+        $data = json_decode(file_get_contents($this->sdmCoreGetCoreDirectoryPath() . '/sdm/data.json'), false);
+        return $data->content->$page->$contentWrapper;
     }
 
     /**

--- a/core/includes/SdmCore.php
+++ b/core/includes/SdmCore.php
@@ -311,6 +311,8 @@ class SdmCore
 
     /**
      * Configure PHP settings and Core settings.
+     * @todo: move ini_set() settings into the settings property of the DataObject so they are
+     * stored instead of hardcoded.
      * @return boolen Returns true regardless of success.
      */
     final public function sdmCoreConfigureCore()
@@ -329,7 +331,8 @@ class SdmCore
         ini_set('session.use_only_cookies', 1);
         ini_set('session.hash_function', 'sha512');
         ini_set('session.hash_bits_per_character', 6);
-        ini_set('session.gc_maxlifetime', 180); // set in seconds | determines how a long a session file can exist before it becomes eligible for Garbage Collection
+        $minutes = array_product([20,60]); // calculate minutes in seconds
+        ini_set('session.gc_maxlifetime', $minutes); // set in seconds | determines how a long a session file can exist before it becomes eligible for Garbage Collection
         ini_set('session.gc_probability', 20); // chance that GC will occur
         ini_set('session.gc_divisor', 100); // probability divisor, if gc_propbability is 50 and gc_divisor is 100 then there is a 50% chance of GC (i.e. 50/100)
         // set include path

--- a/core/includes/SdmCore.php
+++ b/core/includes/SdmCore.php
@@ -129,17 +129,17 @@ class SdmCore
         /* Decode json to get our Data Object. */
         $dataObject = json_decode($coreJson);
 
-        /* Create array of available pages in unmodified DataObject. */
-        $availablePages = array_keys(get_object_vars($dataObject->content));
-
-        /* Create array of available pages formatted to be used as array keys */
-        $availablePagesKeys = array_map('ucwords', $availablePages);
-
-        /* Create core availablePages array using $availablePagesKeys and $availablePages arrays */
-        $this->availablePages = array_combine($availablePagesKeys, $availablePages);
-
         /* If $requestPageOnly === TRUE remove all pages but the requested page from the DataObject. */
         if ($requestPageOnly === true) {
+            /* Create array of available pages in unmodified DataObject. */
+            $availablePages = array_keys(get_object_vars($dataObject->content));
+
+            /* Create array of available pages formatted to be used as array keys */
+            $availablePagesKeys = array_map('ucwords', $availablePages);
+
+            /* Create core availablePages array using $availablePagesKeys and $availablePages arrays */
+            $this->availablePages = array_combine($availablePagesKeys, $availablePages);
+
             /* Get the requested pages page content. This will be used to
              restore $datObject->content after it is unset. */
             $requestedPageContent = (isset($dataObject->content->$requestedPage) === true ? $dataObject->content->$requestedPage : new stdClass());

--- a/core/includes/SdmNms.php
+++ b/core/includes/SdmNms.php
@@ -190,12 +190,15 @@ class SdmNms extends SdmGatekeeper
     }
 
     /**
-     * <p>Gets the html needed to display the wrappers menus and incorporates it into the page</p>
-     * @param string $wrapper <p>The wrapper to get menus for</p>
-     * @param string $wrapperAssembledContent <p>The wrapper html as it is assembled so far,
+     * Gets the html needed to display the wrappers menus and incorporates it into the page.
+     *
+     * @param string $wrapper The wrapper to get menus for.
+     *
+     * @param string $wrapperAssembledContent The wrapper html as it is assembled so far,
      * the menu incorporation happens last in order to allow apps to modify menus prior to
-     * incorporating them into the page</p>
-     * @return string <p>The html for the menus.</p>
+     * incorporating them into the page.
+     *
+     * @return string The html for the menus.
      */
     public function sdmNmsGetWrapperMenusHtml($wrapper, $wrapperAssembledContent)
     {
@@ -219,18 +222,27 @@ class SdmNms extends SdmGatekeeper
     }
 
     /**
-     * Get a single stored menu and return it as an html formatted string
-     * @param mixed $menuId An integer or stirng that is equal to the id of the menu we wish to get
-     * @return string An html formated string representation of the menu
+     * Get a single stored menu and return it as an html formatted string.
+     *
+     * @param mixed $menuId An integer or string that is equal to the id of the menu we wish to get
+     *
+     * @return string An html formatted string representation of the menu.
      */
     public function sdmNmsGetMenuHtml($menuId)
     {
+        /* Determine current user's role. */
         $currentUserRole = (SdmGatekeeper::sdmGatekeeperAuthenticate() === true ? 'root' : 'basic_user'); // this is a dev role, the users role should be determined by the Sdm Gatekeeper once it is built
+
+        /* Get the menu's html. */
         $menu = $this->sdmNmsGetMenu($menuId);
-        // @todo : there is no need to instatiate SdmCore() here since this class is a child of SdmCore().
-        // if $currentUserRole exists in menuKeyholders array show menu || if the special role "all" exists in the menuKeyholders array we assume all users have accsess and show menu || we no longer  assume that all users have accsess to this menu if menuKeyholders is null
-        if (in_array($currentUserRole, $menu->menuKeyholders) || in_array('all', $menu->menuKeyholders)) { // we check three things, if the menuKeyholders property is null we assume all users can accsess this menu, if it is not null we check if the users role exists in the menuKeyholders array, we also do a check to see if the 'all' value exists in the menuKeyholders array, if 'all' is present then the menu will be available to all users regardless of the other roles set in menuKeyholders
-            $html = (in_array($this->sdmCoreDetermineRequestedPage(), $menu->displaypages) === true || in_array('all', $menu->displaypages) === true ? $this->sdmNmsBuildMenuHtml($menu) : '<!-- Menu "' . $menu->menuDisplayName . '" Placeholder -->'); //$this->sdmNmsBuildMenuHtml($menu);
+
+        /* Make sure user has permission to use this menu. *.
+         * - If the menuKeyholders property is null we assume all users can accsess this menu,
+         * - If it is not null we check if the users role exists in the menuKeyholders array,
+         * - If the special value 'all' is present then the menu will be available to all users
+         *   regardless of what other roles are set in $menu->menuKeyholders. */
+        if (in_array($currentUserRole, $menu->menuKeyholders) || in_array('all', $menu->menuKeyholders)) {
+            $html = (in_array($this->sdmCoreDetermineRequestedPage(), $menu->displaypages) === true || in_array('all', $menu->displaypages) === true ? $this->sdmNmsBuildMenuHtml($menu) : '<!-- Menu "' . $menu->menuDisplayName . '" Placeholder -->');
         }
         return (isset($html) && $html !== '' ? $html : false);
     }

--- a/themes/jamiesBlog/css/forms.css
+++ b/themes/jamiesBlog/css/forms.css
@@ -1,0 +1,36 @@
+/*
+    Document   : forms
+    Created on : Oct 28, 2015, 5:20:40 PM
+    Author     : seviforeman
+    Description:
+        Purpose of the stylesheet follows.
+*/
+
+/** Forms */
+input, text, textarea, select {
+    display: block;
+    border-radius: 4px;
+    margin: 5px 0 20px 0;
+}
+
+textarea {
+    max-width: 100%;
+    min-width: 100%;
+    min-height: 150px;
+}
+select {
+    margin-top: 15px;
+}
+[type*='radio'] {
+    display: inline-block;
+    margin: 20px;
+}
+/* Tablet Styles */
+@media only screen and (min-width: 600px) {
+
+}
+
+/* Desktop Styles */
+@media only screen and (min-width: 768px) {
+
+}

--- a/themes/jamiesBlog/css/layout.css
+++ b/themes/jamiesBlog/css/layout.css
@@ -1,0 +1,118 @@
+/*
+    Document   : layout
+    Created on : Oct 27, 2015, 4:31:01 PM
+    Author     : seviforeman
+    Description:
+        Responsive theme for the SDM CMS. This theme
+        is a mobile first design and will adjust it's
+        styles based on screen size;
+
+        This file specifically sets the layout styles for the theme.
+*/
+
+/*
+    The CSS3 box-sizing property allows us to
+    include the padding and border in an element's
+    total width and height. This prevents borders and
+    padding from changing an elements overall width.
+    @see http://www.w3schools.com/css/css3_box-sizing.asp
+    for more info.
+        Another article, @see https://css-tricks.com/box-sizing/,
+    also explains why it is important to insure including
+    pseudo elements in the application of box-sizing. However,
+    as the article points out, the inclination to simply set...:
+        *, *:before, *:after {box-sizing: border-bos;}
+    ... will prevent designers from utilizing other
+    box-sizing properties if needed, so to solve this
+    set box-sizing to border-box for the parent html
+    element and have all other elements inherit their
+    box-sizing, this way elements can use other box-sizing
+    properties while all other elements default to the border-box
+    property;
+*/
+
+html {
+    /* for older browsers */
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    /* moder browsers */
+    box-sizing: border-box;
+}
+*, *:before, *:after {
+    /* for older browsers */
+    -webkit-box-sizing: inherit;
+    -moz-box-sizing: inherit;
+    /* moder browsers */
+    box-sizing: inherit;
+}
+
+
+/*
+    Design for mobile first. By default set all
+    column widths to 100% to adjust for smaller
+    screens
+*/
+[class*="col-"] {
+    width: 100%;
+    float: left;
+    padding: 15px;
+}
+
+/**
+    The columns inside a row are all floating
+    to the left, and are therefore taken out
+    of the flow of the page, and other elements
+    will be placed as if the columns do not
+    exist. To prevent this, we will add a style
+    that clears the flow after each row.
+    (i.e., after each element with class .row)
+**/
+.row:after {
+    content: ""; /* If set this sting will be placed after each row. Can be useful during theme development to see where various elements are in the page */
+    clear: both;
+    display: block;
+}
+
+/* elements with class spacer will have no border and can be used to create space between columns */
+.spacer {
+    border:none;
+}
+
+
+/* Tablet Styles */
+@media only screen and (min-width: 600px) {
+    /* For tablets: */
+    .col-m-05 {width: 4.16%;}
+    .col-m-1 {width: 8.33%;}
+    .col-m-2 {width: 16.66%;}
+    .col-m-3 {width: 25%;}
+    .col-m-4 {width: 33.33%;}
+    .col-m-5 {width: 41.66%;}
+    .col-m-6 {width: 50%;}
+    .col-m-7 {width: 58.33%;}
+    .col-m-75 {width: 62.49%;}
+    .col-m-8 {width: 66.66%;}
+    .col-m-9 {width: 75%;}
+    .col-m-10 {width: 83.33%;}
+    .col-m-11 {width: 91.66%;}
+    .col-m-12 {width: 100%;}
+}
+
+/* Desktop Styles */
+@media only screen and (min-width: 768px) {
+    /* Col styles For desktop: */
+    .col-m-05 {width: 4.16%;}
+    .col-1 {width: 8.33%;}
+    .col-2 {width: 16.66%;}
+    .col-3 {width: 25%;}
+    .col-4 {width: 33.33%;}
+    .col-5 {width: 41.66%;}
+    .col-6 {width: 50%;}
+    .col-7 {width: 58.33%;}
+    .col-m-75 {width: 62.49%;}
+    .col-8 {width: 66.66%;}
+    .col-9 {width: 75%;}
+    .col-10 {width: 83.33%;}
+    .col-11 {width: 91.66%;}
+    .col-12 {width: 100%;}
+}

--- a/themes/jamiesBlog/css/menus.css
+++ b/themes/jamiesBlog/css/menus.css
@@ -1,0 +1,61 @@
+/*
+    Document   : menus
+    Created on : Oct 28, 2015, 5:20:29 PM
+    Author     : seviforeman
+    Description:
+        Purpose of the stylesheet follows.
+*/
+
+/** Menus */
+
+ul {
+    list-style: none; /* get rid of bullets for list elemetns */
+    padding-left: 0; /* remove indentation of list elements */
+}
+
+/** Links */
+/** default link styles */
+a {
+    text-decoration: none;
+}
+a:link {
+    color: #fdf5f0;
+}
+
+a:visited {
+    color: #fdf5f0;
+}
+
+a:hover {
+    color: #777777;
+}
+
+a:active {
+    color: #777777;;
+}
+
+/* Tablet Styles */
+@media only screen and (min-width: 600px) {
+
+}
+
+/* Desktop Styles */
+@media only screen and (min-width: 768px) {
+    /** menu styles **/
+    .horizontal-menu {
+        font-size: 1.2em; /* slightly larger then base font-size */
+        list-style-type: none;
+        padding: 0;
+        margin: 0;
+
+    }
+
+    .horizontal-menu li {
+        display: inline-block; /* Use inline-block so we can apply margins */
+        margin: 0 15px 0 15px; /* Align with "col-*" left margins @see [class*="col-"] {} in layout.css for correct pixel measurements, margin left and right for horizontal-menu li {} should = padding in [class*="col-"]{} */
+    }
+
+    .horizontal-menu a {
+        text-decoration: none;
+    }
+}

--- a/themes/jamiesBlog/css/style-classes.css
+++ b/themes/jamiesBlog/css/style-classes.css
@@ -1,0 +1,76 @@
+/*
+    Document   : style-classes
+    Created on : Oct 28, 2015, 5:27:39 PM
+    Author     : seviforeman
+    Description:
+        Purpose of the stylesheet follows.
+*/
+
+body {
+    background: #ff9c83;
+    margin: 0;
+    /** the following three lines prevent bg from repeating **/
+    height: 100%;
+    background-repeat: no-repeat;
+    background-attachment: fixed;
+}
+.jamiesBlog {
+    color: #fdf5f0;
+    font-size: 24px;
+    font-family: serif;
+}
+
+
+.border-bottom {
+    border-top-color:#000000;
+    border-right-color:#000000;
+    border-bottom-color:#ffffff;
+    border-left-color:#000000;
+    border-width:5px;
+    border-radius:0;
+    border-style:none none double none;
+}
+
+.row-min-wid-fix {
+    min-width: 0;
+}
+.rounded {
+    border-radius:20px;
+}
+
+.padded-row {
+    padding: 20px;
+}
+
+/* Tablet Styles */
+@media only screen and (min-width: 600px) {
+    body {
+        background: #ff9c83;
+        margin: 0;
+        /** the following three lines prevent bg from repeating **/
+        height: 100%;
+        background-repeat: no-repeat;
+        background-attachment: fixed;
+    }
+    .row-min-wid-fix {
+        min-width: 0;
+    }
+}
+
+/* Desktop Styles */
+@media only screen and (min-width: 768px) {
+    body{
+        background: #ff9c83;
+        margin: 0;
+        /** the following three lines prevent bg from repeating **/
+        height: 100%;
+        background-repeat: no-repeat;
+        background-attachment: fixed;
+    }
+
+    /* Prevent elements from collapsing on window resize on desktops by setting min-width for desktops */
+    .row-min-wid-fix {
+        min-width: 1100px;
+    }
+}
+

--- a/themes/jamiesBlog/css/wrappers.css
+++ b/themes/jamiesBlog/css/wrappers.css
@@ -1,0 +1,29 @@
+/*
+    Document   : wrappers
+    Created on : Oct 28, 2015, 5:29:19 PM
+    Author     : seviforeman
+    Description:
+        Purpose of the stylesheet follows.
+*/
+
+/* Wrappers */
+#side-menu, #main_content {
+    background: #3d0d0b;
+    opacity: .9;
+}
+
+#top-menu {
+    text-align: center;
+}
+/* Tablet Styles */
+@media only screen and (min-width: 600px) {
+
+}
+
+/* Desktop Styles */
+@media only screen and (min-width: 768px) {
+    /* Wrappers */
+    #footer {
+        text-align: center;
+    }
+}

--- a/themes/jamiesBlog/jamiesBlog.as
+++ b/themes/jamiesBlog/jamiesBlog.as
@@ -1,0 +1,3 @@
+stylesheets=css/layout,css/forms,css/menus,css/style-classes,css/wrappers;
+scripts=none;
+meta=[name:description, content:Website powered by the SDM CMS], [name:author, content:Sevi Donnelly Foreman], [http-equiv:refresh, content:3000], [name:viewport, content:[width=device-width|initial-scale=1.0]];

--- a/themes/jamiesBlog/page.php
+++ b/themes/jamiesBlog/page.php
@@ -1,0 +1,37 @@
+<!-- row 1 -->
+<div class="row row-min-wid-fix">
+    <div id="top-menu" class="col-12 col-m-12 border-bottom">
+        <?php
+        echo $sdmassembler->sdmAssemblerGetContentHtml('top-menu');
+        ?>
+    </div>
+</div>
+<!-- row 2 -->
+<div class="row row-min-wid-fix padded-row">
+    <?php
+    $sidebar = $sdmassembler->sdmAssemblerGetContentHtml('side-menu');
+    $sidebarInvalidValues = array(null, '', '<!-- side-menu placeholder -->');
+    $sideBarExists = (in_array($sidebar, $sidebarInvalidValues) === true ? false : true);
+    if ($sideBarExists === true) {
+        ?>
+        <div id="side-menu" class="col-2 col-m-2 rounded">
+            <?php
+            echo $sdmassembler->sdmAssemblerGetContentHtml('side-menu');
+            ?>    </div>
+        <div id="locked-spacer" class="col-05 col-m-05 spacer"></div>
+    <?php } ?>
+    <div id="main_content"
+         class="<?php echo($sideBarExists === true ? 'col-75 col-m-75' : 'col-12 col-m-12'); ?> rounded">
+        <?php
+        echo $sdmassembler->sdmAssemblerGetContentHtml('main_content');
+        ?>
+    </div>
+</div>
+<!-- row 3 -->
+<div class="row row-min-wid-fix">
+    <div id="footer" class="col-12 col-m-12">
+        <?php
+        echo $sdmassembler->sdmAssemblerGetContentHtml('footer');
+        ?>
+    </div>
+</div>

--- a/themes/sdmResponsive/sdmResponsive.as
+++ b/themes/sdmResponsive/sdmResponsive.as
@@ -1,3 +1,3 @@
 stylesheets=css/layout,css/forms,css/menus,css/style-classes,css/wrappers;
 scripts=none;
-meta=none;
+meta=[name:description, content:Website powered by the SDM CMS], [name:author, content:Sevi Donnelly Foreman], [http-equiv:refresh, content:3000], [name:viewport, content:[width=device-width|initial-scale=1.0]];

--- a/themes/sdmResponsiveBlack/sdmResponsiveBlack.as
+++ b/themes/sdmResponsiveBlack/sdmResponsiveBlack.as
@@ -1,3 +1,3 @@
 stylesheets=css/layout,css/forms,css/menus,css/style-classes,css/wrappers;
 scripts=js/anibg;
-meta=none;
+meta=[name:description, content:Website powered by the SDM CMS], [name:author, content:Sevi Donnelly Foreman], [http-equiv:refresh, content:3000], [name:viewport, content:[width=device-width|initial-scale=1.0]];

--- a/themes/sdmResponsiveBlue/css/forms.css
+++ b/themes/sdmResponsiveBlue/css/forms.css
@@ -1,0 +1,36 @@
+/*
+    Document   : forms
+    Created on : Oct 28, 2015, 5:20:40 PM
+    Author     : seviforeman
+    Description:
+        Purpose of the stylesheet follows.
+*/
+
+/** Forms */
+input, text, textarea, select {
+    display: block;
+    border-radius: 4px;
+    margin: 5px 0 20px 0;
+}
+
+textarea {
+    max-width: 100%;
+    min-width: 100%;
+    min-height: 150px;
+}
+select {
+    margin-top: 15px;
+}
+[type*='radio'] {
+    display: inline-block;
+    margin: 20px;
+}
+/* Tablet Styles */
+@media only screen and (min-width: 600px) {
+
+}
+
+/* Desktop Styles */
+@media only screen and (min-width: 768px) {
+
+}

--- a/themes/sdmResponsiveBlue/css/layout.css
+++ b/themes/sdmResponsiveBlue/css/layout.css
@@ -1,0 +1,114 @@
+/*
+    Document   : layout
+    Created on : Oct 27, 2015, 4:31:01 PM
+    Author     : seviforeman
+    Description:
+        Responsive theme for the SDM CMS. This theme
+        is a mobile first design and will adjust it's
+        styles based on screen size;
+
+        This file specifically sets the layout styles for the theme.
+*/
+
+/*
+    The CSS3 box-sizing property allows us to
+    include the padding and border in an element's
+    total width and height. This prevents borders and
+    padding from changing an elements overall width.
+    @see http://www.w3schools.com/css/css3_box-sizing.asp
+    for more info.
+        Another article, @see https://css-tricks.com/box-sizing/,
+    also explains why it is important to insure including
+    pseudo elements in the application of box-sizing. However,
+    as the article points out, the inclination to simply set...:
+        *, *:before, *:after {box-sizing: border-bos;}
+    ... will prevent designers from utilizing other
+    box-sizing properties if needed, so to solve this
+    set box-sizing to border-box for the parent html
+    element and have all other elements inherit their
+    box-sizing, this way elements can use other box-sizing
+    properties while all other elements default to the border-box
+    property;
+*/
+
+html {
+    /* for older browsers */
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    /* moder browsers */
+    box-sizing: border-box;
+}
+*, *:before, *:after {
+    /* for older browsers */
+    -webkit-box-sizing: inherit;
+    -moz-box-sizing: inherit;
+    /* moder browsers */
+    box-sizing: inherit;
+}
+
+
+/*
+    Design for mobile first. By default set all
+    column widths to 100% to adjust for smaller
+    screens
+*/
+[class*="col-"] {
+    width: 100%;
+    float: left;
+    padding: 15px;
+}
+
+/**
+    The columns inside a row are all floating
+    to the left, and are therefore taken out
+    of the flow of the page, and other elements
+    will be placed as if the columns do not
+    exist. To prevent this, we will add a style
+    that clears the flow after each row.
+    (i.e., after each element with class .row)
+**/
+.row:after {
+    content: ""; /* If set this sting will be placed after each row. Can be useful during theme development to see where various elements are in the page */
+    clear: both;
+    display: block;
+}
+
+/* elements with class spacer will have no border and can be used to create space between columns */
+.spacer {
+    border:none;
+}
+
+
+/* Tablet Styles */
+@media only screen and (min-width: 600px) {
+    /* For tablets: */
+    .col-m-1 {width: 8.33%;}
+    .col-m-2 {width: 16.66%;}
+    .col-m-3 {width: 25%;}
+    .col-m-4 {width: 33.33%;}
+    .col-m-5 {width: 41.66%;}
+    .col-m-6 {width: 50%;}
+    .col-m-7 {width: 58.33%;}
+    .col-m-8 {width: 66.66%;}
+    .col-m-9 {width: 75%;}
+    .col-m-10 {width: 83.33%;}
+    .col-m-11 {width: 91.66%;}
+    .col-m-12 {width: 100%;}
+}
+
+/* Desktop Styles */
+@media only screen and (min-width: 768px) {
+    /* Col styles For desktop: */
+    .col-1 {width: 8.33%;}
+    .col-2 {width: 16.66%;}
+    .col-3 {width: 25%;}
+    .col-4 {width: 33.33%;}
+    .col-5 {width: 41.66%;}
+    .col-6 {width: 50%;}
+    .col-7 {width: 58.33%;}
+    .col-8 {width: 66.66%;}
+    .col-9 {width: 75%;}
+    .col-10 {width: 83.33%;}
+    .col-11 {width: 91.66%;}
+    .col-12 {width: 100%;}
+}

--- a/themes/sdmResponsiveBlue/css/menus.css
+++ b/themes/sdmResponsiveBlue/css/menus.css
@@ -1,0 +1,77 @@
+/*
+    Document   : menus
+    Created on : Oct 28, 2015, 5:20:29 PM
+    Author     : seviforeman
+    Description:
+        Purpose of the stylesheet follows.
+*/
+
+/** Menus */
+
+ul {
+    list-style: none; /* get rid of bullets for list elemetns */
+    padding-left: 0; /* remove indentation of list elements */
+}
+
+/** Links */
+/** default link styles */
+a {
+    text-decoration: none;
+}
+a:link {
+    color: #ffffff;
+}
+
+a:visited {
+    color: #ffffff;
+}
+
+a:hover {
+    color: #0099FF;
+}
+
+a:active {
+    color: #0099FF;
+}
+/** custom links */
+.homelink a:link {
+    color: #99ccff;
+}
+
+.homelink a:visited {
+    color: #99ccff;
+}
+
+.homelink a:hover {
+    color: #3399ff;
+}
+
+.homelink a:active {
+    color: #00DDff;
+}
+
+/* Tablet Styles */
+@media only screen and (min-width: 600px) {
+
+}
+
+/* Desktop Styles */
+@media only screen and (min-width: 768px) {
+    /** menu styles **/
+    .horizontal-menu {
+        font-size: 1.2em; /* slightly larger then base font-size */
+        list-style-type: none;
+        padding: 0;
+        margin: 0;
+
+    }
+
+    .horizontal-menu li {
+        display: inline-block; /* Use inline-block so we can apply margins */
+        margin: 0 15px 0 15px; /* Align with "col-*" left margins @see [class*="col-"] {} in layout.css for correct pixel measurements, margin left and right for horizontal-menu li {} should = padding in [class*="col-"]{} */
+    }
+
+    .horizontal-menu a {
+        text-decoration: none;
+    }
+}

--- a/themes/sdmResponsiveBlue/css/style-classes.css
+++ b/themes/sdmResponsiveBlue/css/style-classes.css
@@ -1,0 +1,83 @@
+/*
+    Document   : style-classes
+    Created on : Oct 28, 2015, 5:27:39 PM
+    Author     : seviforeman
+    Description:
+        Purpose of the stylesheet follows.
+*/
+
+body {
+    background: #004C9F;
+    margin: 0;
+    /** the following three lines prevent bg from repeating **/
+    height: 100%;
+    background-repeat: no-repeat;
+    background-attachment: fixed;
+}
+
+.sdmResponsiveBlue {
+    color: #318dff;
+    text-shadow:
+            -1px -1px 0 #000077,
+            1px -1px 0 #000077,
+            -1px 1px 0 #000077,
+            1px 1px 0 #000077;
+    font-size: 24px;
+    font-family: serif;
+}
+
+.border-bottom {
+    border-top-color: #FFFFFF;
+    border-right-color: #FFFFFF;
+    border-bottom-color: #FFFFFF;
+    border-left-color: #FFFFFF;
+    border-width: 5px;
+    border-radius: 0;
+    border-style: none none double none;
+}
+
+.row-min-wid-fix {
+    min-width: 0;
+}
+
+.rounded {
+    border-radius: 20px;
+}
+
+.padded-row {
+    padding: 20px;
+}
+
+/* Tablet Styles */
+@media only screen and (min-width: 600px) {
+    body {
+        background: #004C9F;
+        margin: 0;
+        /** the following three lines prevent bg from repeating **/
+        height: 100%;
+        background-repeat: no-repeat;
+        background-attachment: fixed;
+    }
+
+    .row-min-wid-fix {
+        min-width: 0;
+    }
+}
+
+/* Desktop Styles */
+@media only screen and (min-width: 768px) {
+    body {
+        background: #004C9F;
+        margin: 0;
+        /** the following three lines prevent bg from repeating **/
+        height: 100%;
+        background-repeat: no-repeat;
+        background-attachment: fixed;
+    }
+
+    /* Prevent elements from collapsing on window resize on desktops by setting min-width for desktops */
+    .row-min-wid-fix {
+        min-width: 1100px;
+    }
+}
+

--- a/themes/sdmResponsiveBlue/css/wrappers.css
+++ b/themes/sdmResponsiveBlue/css/wrappers.css
@@ -1,0 +1,27 @@
+/*
+    Document   : wrappers
+    Created on : Oct 28, 2015, 5:29:19 PM
+    Author     : seviforeman
+    Description:
+        Purpose of the stylesheet follows.
+*/
+
+/* Wrappers */
+#side-menu, #main_content {
+    background: #244769;
+    opacity: .79;
+    border: 5px double #FFFFFF;
+}
+
+/* Tablet Styles */
+@media only screen and (min-width: 600px) {
+
+}
+
+/* Desktop Styles */
+@media only screen and (min-width: 768px) {
+    /* Wrappers */
+    #footer {
+        text-align: center;
+    }
+}

--- a/themes/sdmResponsiveBlue/page.php
+++ b/themes/sdmResponsiveBlue/page.php
@@ -1,0 +1,37 @@
+<!-- row 1 -->
+<div class="row row-min-wid-fix">
+    <div id="top-menu" class="col-12 col-m-12 border-bottom">
+        <?php
+        echo $sdmassembler->sdmAssemblerGetContentHtml('top-menu');
+        ?>
+    </div>
+</div>
+<!-- row 2 -->
+<div class="row row-min-wid-fix padded-row">
+    <?php
+    $sidebar = $sdmassembler->sdmAssemblerGetContentHtml('side-menu');
+    $sidebarInvalidValues = array(null, '', '<!-- side-menu placeholder -->');
+    $sideBarExists = (in_array($sidebar, $sidebarInvalidValues) === true ? false : true);
+    if ($sideBarExists === true) {
+        ?>
+        <div id="side-menu" class="col-3 col-m-3 rounded">
+            <?php
+            echo $sdmassembler->sdmAssemblerGetContentHtml('side-menu');
+            ?>    </div>
+        <div id="locked-spacer" class="col-1 col-m-1 spacer"></div>
+    <?php } ?>
+    <div id="main_content"
+         class="<?php echo($sideBarExists === true ? 'col-8 col-m-8' : 'col-12 col-m-12'); ?> rounded">
+        <?php
+        echo $sdmassembler->sdmAssemblerGetContentHtml('main_content');
+        ?>
+    </div>
+</div>
+<!-- row 3 -->
+<div class="row row-min-wid-fix">
+    <div id="footer" class="col-12 col-m-12">
+        <?php
+        echo $sdmassembler->sdmAssemblerGetContentHtml('footer');
+        ?>
+    </div>
+</div>

--- a/themes/sdmResponsiveBlue/sdmResponsiveBlue.as
+++ b/themes/sdmResponsiveBlue/sdmResponsiveBlue.as
@@ -1,0 +1,1 @@
+stylesheets=css/layout,css/forms,css/menus,css/style-classes,css/wrappers;

--- a/themes/sdmResponsiveBlue/sdmResponsiveBlue.as
+++ b/themes/sdmResponsiveBlue/sdmResponsiveBlue.as
@@ -1,1 +1,2 @@
 stylesheets=css/layout,css/forms,css/menus,css/style-classes,css/wrappers;
+meta=[name:description, content:Website powered by the SDM CMS], [name:author, content:Sevi Donnelly Foreman], [http-equiv:refresh, content:3000], [name:viewport, content:[width=device-width|initial-scale=1.0]];

--- a/themes/sdmResponsiveFade/js/anibg.js
+++ b/themes/sdmResponsiveFade/js/anibg.js
@@ -6,8 +6,11 @@ $(document).ready(function () {
     $("html body").css('background-image', 'url(' + imageUrl + ')');
 
     /* Create an array of n random colors. */
-    var colorsArr = generateColors(3);
+    var colorsArr = generateColors(256);
+
+    /* Add div to page to display current background color */
+    $('body').prepend('<div style="background: #000000; font-size: .5em; border-radius: 9px; text-align: center; width:27%; margin:5px auto; opacity:.75;" id="colors"></div>');
 
     /* Animate page bg using colorsArr. */
-    aniBg("html body", colorsArr, 1420, 0);
+    aniBg("html body", colorsArr, 5420, 0);
 });

--- a/themes/sdmResponsiveFade/js/anibg.js
+++ b/themes/sdmResponsiveFade/js/anibg.js
@@ -9,7 +9,7 @@ $(document).ready(function () {
     var colorsArr = generateColors(256);
 
     /* Add div to page to display current background color */
-    $('body').prepend('<div style="background: #000000; font-size: .5em; border-radius: 9px; text-align: center; width:27%; margin:5px auto; opacity:.75;" id="colors"></div>');
+    $('body').prepend('<div style="background: #000000; font-size: .5em; border-radius: 9px; text-align: center; width:27%; margin:5px auto; padding: 2px 0px 2px 0px; opacity:.75;" id="colors">Starting background color animation...</div>');
 
     /* Animate page bg using colorsArr. */
     aniBg("html body", colorsArr, 5420, 0);

--- a/themes/sdmResponsiveFade/js/anibgfunctions.js
+++ b/themes/sdmResponsiveFade/js/anibgfunctions.js
@@ -8,7 +8,7 @@ function aniBg(target, colors, aniTime, index) {
     var limit = colors.length;
     var newIndex = ((index + 1) < limit) ? index + 1 : 0; // reset index if {index + 1} !< limit;
     // display current color | newIndex represents the current color
-    fadeInText('#colors', 'Current Background Color: <span style="color:' + colors[index] + '">' + colors[index] + '</span>');
+    fadeInText('#colors', '<p>Color Cycle: ' + (index + 1) + '</p><p>Current Background Color: <span style="color:' + colors[index] + '">' + colors[index] + '</span></p>');
     $(target).animate({backgroundColor: colors[index]}, aniTime, function () {
         $(target).animate({backgroundColor: colors[newIndex]}, aniTime - (aniTime / 2), function () {
             aniBg(target, colors, aniTime, newIndex);

--- a/themes/sdmResponsiveFade/js/anibgfunctions.js
+++ b/themes/sdmResponsiveFade/js/anibgfunctions.js
@@ -7,6 +7,8 @@
 function aniBg(target, colors, aniTime, index) {
     var limit = colors.length;
     var newIndex = ((index + 1) < limit) ? index + 1 : 0; // reset index if {index + 1} !< limit;
+    // display current color | newIndex represents the current color
+    fadeInText('#colors', 'Current Background Color: <span style="color:' + colors[index] + '">' + colors[index] + '</span>');
     $(target).animate({backgroundColor: colors[index]}, aniTime, function () {
         $(target).animate({backgroundColor: colors[newIndex]}, aniTime - (aniTime / 2), function () {
             aniBg(target, colors, aniTime, newIndex);
@@ -14,6 +16,17 @@ function aniBg(target, colors, aniTime, index) {
     });
 }
 
+/**
+ * Fades text into an element.
+ * @param string target The target element.
+ * @param string text The text to fade into the target element.
+ *                    Note: text will replace any existing content.
+ */
+function fadeInText(target, text) {
+    $(target).fadeOut(function () {
+        $(this).html(text);
+    }).fadeIn();
+}
 /**
  * Returns a random value from an array.
  * @param arr The array to pick from.

--- a/themes/sdmResponsiveFade/js/anibgfunctions.js
+++ b/themes/sdmResponsiveFade/js/anibgfunctions.js
@@ -8,7 +8,7 @@ function aniBg(target, colors, aniTime, index) {
     var limit = colors.length;
     var newIndex = ((index + 1) < limit) ? index + 1 : 0; // reset index if {index + 1} !< limit;
     // display current color | newIndex represents the current color
-    fadeInText('#colors', '<p>Color Cycle: ' + (index + 1) + '</p><p>Current Background Color: <span style="color:' + colors[index] + '">' + colors[index] + '</span></p>');
+    fadeInText('#colors', '<p>Color Cycle: ' + (index + 1) + ' out of ' + limit + '</p><p>Current Background Color: <span style="font-style: italic; color:' + colors[index] + '">' + colors[index] + '</span></p>');
     $(target).animate({backgroundColor: colors[index]}, aniTime, function () {
         $(target).animate({backgroundColor: colors[newIndex]}, aniTime - (aniTime / 2), function () {
             aniBg(target, colors, aniTime, newIndex);

--- a/themes/sdmResponsiveFade/js/anibgfunctions.js
+++ b/themes/sdmResponsiveFade/js/anibgfunctions.js
@@ -7,8 +7,11 @@
 function aniBg(target, colors, aniTime, index) {
     var limit = colors.length;
     var newIndex = ((index + 1) < limit) ? index + 1 : 0; // reset index if {index + 1} !< limit;
-    // display current color | newIndex represents the current color
-    fadeInText('#colors', '<p>Color Cycle: ' + (index + 1) + ' out of ' + limit + '</p><p>Current Background Color: <span style="font-style: italic; color:' + colors[index] + '">' + colors[index] + '</span></p>');
+    /* display current color | newIndex represents the current color */
+    var text = '<p>Color Cycle: ' + (index + 1) + ' out of ' + limit +
+        '</p><p>Current Background Color: <span style="font-style: italic; color:' + colors[index] + '">'
+        + colors[index] + '</span></p>';
+    fadeInText('#colors', text);
     $(target).animate({backgroundColor: colors[index]}, aniTime, function () {
         $(target).animate({backgroundColor: colors[newIndex]}, aniTime - (aniTime / 2), function () {
             aniBg(target, colors, aniTime, newIndex);

--- a/themes/sdmResponsiveFade/sdmResponsiveFade.as
+++ b/themes/sdmResponsiveFade/sdmResponsiveFade.as
@@ -1,3 +1,3 @@
 stylesheets=css/layout, css/forms, css/menus, css/style-classes, css/wrappers;
 scripts=js/anibgfunctions, js/anibg;
-meta=none;
+meta=[name:description, content:Website powered by the SDM CMS], [name:author, content:Sevi Donnelly Foreman], [http-equiv:refresh, content:3000], [name:viewport, content:[width=device-width|initial-scale=1.0]];


### PR DESCRIPTION
This merge features major refactoring of many core components, particularly in the SdmAssembler(). Added new themes sdmResponsiveBlue and jamiesBlog, and further enhanced the sdmResponsiveFade theme to demo use of jQuery in a theme. Added new features to gitTools user app, now the commit log for all commit messages since that last merge of the current branch is shown on the gitTools page, and the current branches status is also shown on the gitTools page. Enhanced helloWorld user app to demo use of jQuery in an app. The SdmAssembler() method sdmAssemblerAssembleEnabledAppProps() now loads core app stylesheets and meta properties, this was not being done even though it should have been. Also, sdmAssemblerAssembleEnabledAppProps() now insures core app header properties are assembled before user app header properties. This merge also contains major cleanup of code and code comments for readability and clarity, as well as other important changes to various core components. For more details see commit message b5b59cd
on January 24, 2016 through commit message c1e05fa on February 7, 2016.