### PR TITLE
Sdmcms cleanup

### DIFF
--- a/core/includes/SdmAssembler.php
+++ b/core/includes/SdmAssembler.php
@@ -158,7 +158,6 @@ class SdmAssembler extends SdmNms
 
         /* Make sure $properties array is not false and is not empty. */
         if ($properties !== false && !empty($properties) === true) {
-
             /* Determine url to components root directory. | Used in assembly of link and script tags for
              property values defined in 'stylesheets' and 'scripts' header properties respectively. */
             $componentUrl = trim($this->sdmAssemblerDetermineComponentUrl($source, $sourceName));

--- a/core/includes/SdmCms.php
+++ b/core/includes/SdmCms.php
@@ -108,7 +108,7 @@ class SdmCms extends SdmCore
 
         /* Extract the wrappers from each of the extracted $tags */
         foreach ($tags as $tag) {
-
+            /* As long as the wrapper does not start with the string "locked" extract it. */
             if (substr(trim($tag->getAttribute('id')), 0, 6) != 'locked') {
                 $data[ucwords(str_replace(array('-', '_'), ' ', trim($tag->getAttribute('id'))))] = trim($tag->getAttribute('id'));
             }

--- a/themes/sdmResponsive/css/style-classes.css
+++ b/themes/sdmResponsive/css/style-classes.css
@@ -49,6 +49,7 @@ body {
 /* Tablet Styles */
 @media only screen and (min-width: 600px) {
     body {
+        background: -webkit-gradient(bottom right, black, #55eeff, black); /* For Chrome and Safari4+ */
         background: -webkit-linear-gradient(left top, black , #77ddff, black); /* For Safari 5.1 to 6.0 */
         background: -o-linear-gradient(bottom right, black ,  #77ddff, black); /* For Opera 11.1 to 12.0 */
         background: -moz-linear-gradient(bottom right, black ,  #77ddff, black); /* For Firefox 3.6 to 15 */
@@ -67,6 +68,7 @@ body {
 /* Desktop Styles */
 @media only screen and (min-width: 768px) {
     body{
+        background: -webkit-gradient(bottom right, black, #55eeff, black); /* For Chrome and Safari4+ */
         background: -webkit-linear-gradient(left top, black , #99ccff, black); /* For Safari 5.1 to 6.0 */
         background: -o-linear-gradient(bottom right, black , #99ccff, black); /* For Opera 11.1 to 12.0 */
         background: -moz-linear-gradient(bottom right, black , #99ccff, black); /* For Firefox 3.6 to 15 */


### PR DESCRIPTION
Cleaned up code in various components. Added missing vendor prefixes for Chrome and Safari4+ in sdmResponsive theme's style-classes.css.