### PR TITLE
Sdmcms cleanup

### DIFF
--- a/apps/helloWorld/helloWorld.cm
+++ b/apps/helloWorld/helloWorld.cm
@@ -1,0 +1,1 @@
+jQuery, jQueryUi

--- a/core/apps/contentManager/contentManager.as
+++ b/core/apps/contentManager/contentManager.as
@@ -1,3 +1,3 @@
-stylesheets = css / cm - styles;
-scripts = js / cm;
-meta =;
+stylesheets=css/cm-styles;
+scripts=js/cm;
+meta=;

--- a/core/apps/contentManager/contentManager.as
+++ b/core/apps/contentManager/contentManager.as
@@ -1,0 +1,3 @@
+stylesheets = css / cm - styles;
+scripts = js / cm;
+meta =;

--- a/core/apps/contentManager/contentManager.cm
+++ b/core/apps/contentManager/contentManager.cm
@@ -1,0 +1,1 @@
+jQuery, jQueryUi

--- a/core/apps/contentManager/css/cm-styles.css
+++ b/core/apps/contentManager/css/cm-styles.css
@@ -1,4 +1,8 @@
+/**
+ * This stylesheet defines styles for the contentManager core app and it's components.
+ */
 
+/* Misc. styles. */
 .border-rounded {
     border: 2px solid #66CCCC;
     border-radius: 9px;
@@ -11,4 +15,48 @@
 
 .border-dotted {
     border-style: dotted;
+}
+
+/* Enabled app link styles. */
+.cm-app-enabled a:link {
+    color: #00FF7F;
+}
+
+.cm-app-enabled a:hover {
+    color: #0099FF;
+}
+
+.cm-app-enabled a:active {
+    color: inherit;
+}
+
+.cm-app-enabled a:visited {
+    color: #00FF7F;
+}
+
+/* Enabled dependency link styles. */
+.cm-dependency-enabled a:link {
+    color: #00FF7F;
+}
+
+.cm-dependency-enabled a:hover {
+    color: #0099FF;
+}
+
+.cm-dependency-enabled a:active {
+    color: inherit;
+}
+
+.cm-dependency-enabled a:visited {
+    color: #00FF7F;
+}
+
+/* Disabled app styles. */
+.cm-app-disabled {
+    color: #aea4a2;
+}
+
+/* */
+.requiredApp {
+    color: red;
 }

--- a/core/apps/contentManager/css/cm-styles.css
+++ b/core/apps/contentManager/css/cm-styles.css
@@ -1,0 +1,14 @@
+
+.border-rounded {
+    border: 2px solid #66CCCC;
+    border-radius: 9px;
+}
+
+.padded-15 {
+    margin: 0px 0px 15px 0px;
+    padding: 12px 15px 12px 15px;
+}
+
+.border-dotted {
+    border-style: dotted;
+}

--- a/core/apps/contentManager/forms/contentManagerAdministerAppsForm.php
+++ b/core/apps/contentManager/forms/contentManagerAdministerAppsForm.php
@@ -24,24 +24,39 @@ $editcontentform->formElements = array(
 );
 // incrementer to determine place of additional form elements
 $i = 1;
-// Create form elements for each available app
+// Create form elements for each available app excluding required apps.
+$dataObject = $sdmassembler->sdmCoreGetDataObject();
 foreach ($available_apps as $displayValue => $machineValue) {
-    if (property_exists($enabled_apps, $machineValue)) {
-        array_push($editcontentform->formElements, array(
-            'id' => $machineValue,
-            'type' => 'radio',
-            'element' => "$displayValue",
-            'value' => array('on' => 'default_on', 'off' => 'off'),
-            'place' => $i,
-        ));
-    } else {
-        array_push($editcontentform->formElements, array(
-            'id' => $machineValue,
-            'type' => 'radio',
-            'element' => "$displayValue",
-            'value' => array('on' => 'on', 'off' => 'default_off'),
-            'place' => $i,
-        ));
+    switch (property_exists($dataObject->settings->requiredApps, $machineValue)) {
+        case true:
+            array_push($editcontentform->formElements, array(
+                'id' => $machineValue,
+                'type' => 'radio',
+                'element' => "<span class='requiredApp'>$displayValue <i>(This app cannot be disabled because it is required by other apps.)</i></span>",
+                'value' => array('on' => 'default_on'),
+                'place' => $i,
+            ));
+            break;
+
+        default:
+            if (property_exists($enabled_apps, $machineValue)) {
+                array_push($editcontentform->formElements, array(
+                    'id' => $machineValue,
+                    'type' => 'radio',
+                    'element' => "$displayValue",
+                    'value' => array('on' => 'default_on', 'off' => 'off'),
+                    'place' => $i,
+                ));
+            } else {
+                array_push($editcontentform->formElements, array(
+                    'id' => $machineValue,
+                    'type' => 'radio',
+                    'element' => "$displayValue",
+                    'value' => array('on' => 'on', 'off' => 'default_off'),
+                    'place' => $i,
+                ));
+            }
+            break;
     }
     $i++;
 }

--- a/core/apps/contentManager/handlers/contentManagerAdministerAppsFormSubmission.php
+++ b/core/apps/contentManager/handlers/contentManagerAdministerAppsFormSubmission.php
@@ -7,12 +7,6 @@
 /* Initialize app $output. */
 $output = '';
 
-/* Tracks enabled apps. */
-$on = array();
-
-/* Tracks disabled apps. */
-$off = array();
-
 /* Determine currently available apps. */
 $availableApps = $sdmcms->sdmCmsDetermineAvailableApps();
 
@@ -24,53 +18,27 @@ switch (SdmForm::sdmFormGetSubmittedFormValue('content_manager_form_submitted'))
     case 'content_manager_form_submitted':
         /* Loop through available apps updating state if necessary. */
         foreach ($availableApps as $appname => $app) {
-            /* Determine $app's dependencies. Apps this $app is dependent on
-             will be enabled internally, but it's still nice to communicate
-             to the user all apps that have been enabled/disabled, including
-             apps this $app is dependent on. */
+            /* Determine $app's dependencies. */
             $dependencies = $sdmcms->sdmCmsDetermineAppDependencies($app);
+
+            /* Initialize $enabledDependencies array. */
+            $enabledDependencies = array();
 
             /* Determine the state to switch the $app to. */
             $newAppState = SdmForm::sdmFormGetSubmittedFormValue($app);
 
-            /* Switch app state to $newAppState */
-            $sdmcms->sdmCmsSwitchAppState($app, $newAppState);
+            /* Switch app state to $newAppState. */
+            $switch = $sdmcms->sdmCmsSwitchAppState($app, $newAppState);
 
-            /* If $app was enabled add it to the $on array. */
-            if ($newAppState === 'on') {
-                /* As long as $app was not already enabled add it to the $on array */
-                if (!property_exists($initiallyEnabledApps, $app) === true) {
-                    $on[] = $app;
-                }
-
-                /*  */
-                foreach ($dependencies as $dependency) {
-                    $requiredApps[$dependency][] = $app;
-                }
-            }
-
+            /* DEV */
+            $sdmcms->sdmCoreSdmReadArray(['$app' => $app, '$newAppState' => $newAppState,'$switch' =>$switch]);
         }
-        $output .= '<h4>The following apps were enabled:</h4><ul>';
-        foreach ($on as $enabledApp) {
-            $output .= '<li style="color:#00C957;">' . $enabledApp . '</li>';
-        }
-        $output .= '</ul>';
 
-        $output .= '<h4>The following apps were enabled because they are required by another enabled app:</h4><ul>';
-        foreach ($requiredApps as $requiredApp => $dependentApps) {
-            $output .= '<li style="color:#00C957;">' . $requiredApp . ' <span style="color: #ffffff;">(Dependent Apps : ';
-            $numDepApps = count($dependentApps);
-            foreach ($dependentApps as $depKey => $dependentApp) {
-                $output .= $dependentApp . ($depKey === $numDepApps - 1 ? '' : ', ');
-            }
-            $output .= ' )</span></li>';
-        }
-        $output .= '</ul>';
         break;
 
     default:
         $output .= '
-                <div id="contentManager">
+                <div class="cm-error">
                     <p>And error occurred and the form could not be submitted</p>
                 </div>
                 ';

--- a/core/apps/contentManager/handlers/contentManagerAdministerAppsFormSubmission.php
+++ b/core/apps/contentManager/handlers/contentManagerAdministerAppsFormSubmission.php
@@ -16,24 +16,67 @@ $initiallyEnabledApps = $sdmcms->sdmCoreDetermineEnabledApps();
 /* Check if form was submitted successfully. */
 switch (SdmForm::sdmFormGetSubmittedFormValue('content_manager_form_submitted')) {
     case 'content_manager_form_submitted':
+        /* Initialize $switch array */
+        $switch = array();
+
         /* Loop through available apps updating state if necessary. */
         foreach ($availableApps as $appname => $app) {
             /* Determine $app's dependencies. */
             $dependencies = $sdmcms->sdmCmsDetermineAppDependencies($app);
 
-            /* Initialize $enabledDependencies array. */
-            $enabledDependencies = array();
-
             /* Determine the state to switch the $app to. */
             $newAppState = SdmForm::sdmFormGetSubmittedFormValue($app);
 
-            /* Switch app state to $newAppState. */
-            $switch = $sdmcms->sdmCmsSwitchAppState($app, $newAppState);
-
-            /* DEV */
-            $sdmcms->sdmCoreSdmReadArray(['$app' => $app, '$newAppState' => $newAppState,'$switch' =>$switch]);
+            /* Switch app state to $newAppState and push returned data to $switch array. */
+            array_push($switch, $sdmcms->sdmCmsSwitchAppState($app, $newAppState));
         }
 
+        /* Begin building display. */
+        $enabledAppsDisplay = '<h4>The following apps were enabled:</h4>';
+        $enabledDependenciesDisplay = '<h4>The following apps were enabled because they are
+                                depended on by other apps:</h4>';
+        $disabledAppsDisplay = '<h4>The following apps were disabled:</h4>';
+
+        /* Initialize alreadyDisplayed array. */
+        $alreadyDisplayed = array('enabledApps' => array(), 'enabledDependencies' => array(), 'disabledApps' => array());
+
+        /* Finish building display for the $switch array. */
+        foreach ($switch as $appState) {
+            /* Enabled apps. */
+            foreach ($appState['enabledApps'] as $enabledApp) {
+                /* As long as $enabledApp is not already registered in the $alreadyDisplayed array
+                   add $enabledApp to $enabledAppsDisplay. */
+                if (!in_array($enabledApp, $appState['enabledDependencies']) && !in_array($enabledApp, $alreadyDisplayed['enabledApps']) && !property_exists($initiallyEnabledApps, $enabledApp)) {
+                    $enabledAppsDisplay .= '<div class="cm-app-enabled"><a href="' . $sdmassembler->sdmCoreGetRootDirectoryUrl() . '/index.php?page=' . $enabledApp . '">' . $enabledApp . '</a></div>';
+                }
+                /* Register app in $alreadyDisplayed['enabledApps'] array. */
+                array_push($alreadyDisplayed['enabledApps'], $enabledApp);
+            }
+
+            /* Enabled dependencies. */
+            foreach ($appState['enabledDependencies'] as $enabledDependency) {
+                /* As long as $enabledDependency is not already registered in the $alreadyDisplayed array
+                   add $enabledDependency to $enabledAppsDisplay. */
+                if (!in_array($enabledDependency, $alreadyDisplayed['enabledDependencies']) && !property_exists($initiallyEnabledApps, $enabledDependency)) {
+                    $enabledDependenciesDisplay .= '<div class="cm-dependency-enabled"><a href="' . $sdmassembler->sdmCoreGetRootDirectoryUrl() . '/index.php?page=' . $enabledDependency . '">' . $enabledDependency . '</a></div>';
+                }
+                /* Register app in $alreadyDisplayed['enabledApps'] array. */
+                array_push($alreadyDisplayed['enabledDependencies'], $enabledDependency);
+            }
+
+            /* Disabled apps. */
+            foreach ($appState['disabledApps'] as $disabledApp) {
+                /* As long as $disabledApp is not already registered in the $alreadyDisplayed array
+                   add $disabledApps to $enabledAppsDisplay. */
+                if (!in_array($disabledApp, $alreadyDisplayed['disabledApps']) && property_exists($initiallyEnabledApps, $disabledApp)) {
+                    $disabledAppsDisplay .= '<div class="cm-app-disabled">' . $disabledApp . '</div>';
+                }
+                /* Register app in $alreadyDisplayed['disabledApps'] array. */
+                array_push($alreadyDisplayed['disabledApps'], $disabledApp);
+            }
+        }
+
+        $output .= $enabledAppsDisplay . $enabledDependenciesDisplay . $disabledAppsDisplay;
         break;
 
     default:

--- a/core/apps/contentManager/handlers/contentManagerAdministerAppsFormSubmission.php
+++ b/core/apps/contentManager/handlers/contentManagerAdministerAppsFormSubmission.php
@@ -13,44 +13,45 @@ $on = null;
 /* Tracks disabled apps. */
 $off = array();
 
-/* Determine currently enabled apps. */
+/* Determine currently available apps. */
 $availableApps = $sdmcms->sdmCmsDetermineAvailableApps();
 
 /* Check if form was submitted successfully. */
-if (SdmForm::sdmFormGetSubmittedFormValue('content_manager_form_submitted') === 'content_manager_form_submitted') {
-    /* Loop through available apps updating state if necessary. */
-    foreach ($availableApps as $appname => $app) {
-        $newAppState = SdmForm::sdmFormGetSubmittedFormValue($app);
-        $sdmcms->sdmCmsSwitchAppState($app, $newAppState);
-        $on = $sdmcms->sdmCoreDetermineEnabledApps();
-        if ($newAppState !== 'on') {
-            $off[0] = '<span style="color:red;">Reworking the display of disabled apps.!</span>';
+switch(SdmForm::sdmFormGetSubmittedFormValue('content_manager_form_submitted')){
+    case 'content_manager_form_submitted':
+        /* Loop through available apps updating state if necessary. */
+        foreach ($availableApps as $appname => $app) {
+            $newAppState = SdmForm::sdmFormGetSubmittedFormValue($app);
+            $sdmcms->sdmCmsSwitchAppState($app, $newAppState);
+            $on = $sdmcms->sdmCoreDetermineEnabledApps();
+            if ($newAppState !== 'on') {
+                $off[0] = '<span style="color:red;">Reworking the display of disabled apps.!</span>';
+            }
         }
-    }
-    $output .= '<h4>The following apps are enabled:</h4><ul>';
-    foreach ($on as $enabledApp) {
-        $output .= '<li style="color:#00C957;">' . $enabledApp . '</li>';
-    }
-    $output .= '</ul>';
-    $output .= '<h4>The following apps are disabled:</h4><ul>';
-    foreach ($off as $disabledApp) {
-        $output .= '<li style="color:#00BFFF;">' . $disabledApp . '</li>';
-    }
-    $output .= '</ul>';
-    //$sdmcms->sdmCmsSwitchAppState('contentManager', 'off');
-    $output .= '
-                    <!-- contentManager div -->
-                    <div id"contentManager">
-                        <p>Form has been submitted.</p>
-                    </div>
-                    <!-- close contentManager div -->';
-} // form submitted but error occured
-else {
-    $output .= '
+        $output .= '<h4>The following apps are enabled:</h4><ul>';
+        foreach ($on as $enabledApp) {
+            $output .= '<li style="color:#00C957;">' . $enabledApp . '</li>';
+        }
+        $output .= '</ul>';
+        $output .= '<h4>The following apps are disabled:</h4><ul>';
+        foreach ($off as $disabledApp) {
+            $output .= '<li style="color:#00BFFF;">' . $disabledApp . '</li>';
+        }
+        $output .= '</ul>';
+        $output .= '<!-- contentManager div -->
+                <div id"contentManager">
+                  <p>Form has been submitted.</p>
+                </div>
+                <!-- close contentManager div -->';
+        break;
+    default:
+        $output .= '
                 <div id="contentManager">
-                    <p>And error occured and the form could not be submitted</p>
+                    <p>And error occurred and the form could not be submitted</p>
                 </div>
                 ';
+        break;
 }
 
+/* Incorporate app output. */
 $sdmassembler->sdmAssemblerIncorporateAppOutput($output, $options);

--- a/core/apps/contentManager/handlers/contentManagerAdministerAppsFormSubmission.php
+++ b/core/apps/contentManager/handlers/contentManagerAdministerAppsFormSubmission.php
@@ -4,19 +4,28 @@
  * Administer Apps form submission handler for the Content Manager core app.
  */
 
-$output = ''; // passed to SdmAssembler::SdmAssemlberIncorporateAppOutput()
-$on = array(); // used for display
-$off = array(); // used for display
-// form submitted successfully
+/* Initialize app $output. */
+$output = '';
+
+/* Tracks enabled apps. */
+$on = null;
+
+/* Tracks disabled apps. */
+$off = array();
+
+/* Determine currently enabled apps. */
+$availableApps = $sdmcms->sdmCmsDetermineAvailableApps();
+
+/* Check if form was submitted successfully. */
 if (SdmForm::sdmFormGetSubmittedFormValue('content_manager_form_submitted') === 'content_manager_form_submitted') {
-    //$sdmassembler->sdmCoreSdmReadArray($_POST['SdmForm']);
-    foreach ($sdmcms->sdmCmsDetermineAvailableApps() as $appname => $app) {
+
+    /**/
+    foreach ($availableApps as $appname => $app) {
         $newAppState = SdmForm::sdmFormGetSubmittedFormValue($app);
         $sdmcms->sdmCmsSwitchAppState($app, $newAppState);
-        if ($newAppState === 'on') {
-            $on[] = $appname;
-        } else {
-            $off[] = $appname;
+        $on = $sdmcms->sdmCoreDetermineEnabledApps();
+        if ($newAppState !== 'on') {
+            $off[0] = '<span style="color:red;">Reworking the display of disabled apps.!</span>';
         }
     }
     $output .= '<h4>The following apps are enabled:</h4><ul>';

--- a/core/apps/contentManager/handlers/contentManagerAdministerAppsFormSubmission.php
+++ b/core/apps/contentManager/handlers/contentManagerAdministerAppsFormSubmission.php
@@ -18,8 +18,7 @@ $availableApps = $sdmcms->sdmCmsDetermineAvailableApps();
 
 /* Check if form was submitted successfully. */
 if (SdmForm::sdmFormGetSubmittedFormValue('content_manager_form_submitted') === 'content_manager_form_submitted') {
-
-    /**/
+    /* Loop through available apps updating state if necessary. */
     foreach ($availableApps as $appname => $app) {
         $newAppState = SdmForm::sdmFormGetSubmittedFormValue($app);
         $sdmcms->sdmCmsSwitchAppState($app, $newAppState);

--- a/core/apps/contentManager/handlers/contentManagerUpdateContentFormSubmission.php
+++ b/core/apps/contentManager/handlers/contentManagerUpdateContentFormSubmission.php
@@ -25,13 +25,13 @@ if ($page !== 'contentManager') {
         /* Initialize $wrapperStatusHtml. */
         $wrapperStatusHtml = '';
         /* Update each wrapper. */
-        foreach ($sdmcms->sdmCmsDetermineAvailableWrappers() as $dispalyValue => $machineValue) {
+        foreach ($sdmcms->sdmCmsDetermineAvailableWrappers() as $displayValue => $machineValue) {
             /* Update the wrapper in the DataObject. */
             $sdmcms->sdmCmsUpdateContent($page, $machineValue, nl2br($sdmForm->sdmFormGetSubmittedFormValue($machineValue)));
 
             /* Get html that will be used along with the rest of the app $output for each wrapper. */
             $wrapperStatusHtml .= '<div class="border-rounded padded-15 highlight">';
-            $wrapperStatusHtml .= '<p>wrapper name: "' . $dispalyValue . '"';
+            $wrapperStatusHtml .= '<p>wrapper name: "' . $displayValue . '"';
             $wrapperStatusHtml .= '<p>wrapper id: "' . $machineValue . '"</p>';
             $wrapperStatusHtml .= '<p>wrapper content:';
             $wrapperStatusHtml .= ($sdmForm->sdmFormGetSubmittedFormValue($machineValue) === '' ? ' This wrapper has no content.</p>' : '</p><div class="border-rounded padded-15 border-dotted">' . $sdmForm->sdmFormGetSubmittedFormValue($machineValue) . '</p></div>');

--- a/core/apps/contentManager/handlers/contentManagerUpdateContentFormSubmission.php
+++ b/core/apps/contentManager/handlers/contentManagerUpdateContentFormSubmission.php
@@ -33,8 +33,8 @@ if ($page !== 'contentManager') {
             $wrapperStatusHtml .= '<div class="border-rounded padded-15 highlight">';
             $wrapperStatusHtml .= '<p>wrapper name: "' . $dispalyValue . '"';
             $wrapperStatusHtml .= '<p>wrapper id: "' . $machineValue . '"</p>';
-            $wrapperStatusHtml .= '<p>wrapper content:</p>';
-            $wrapperStatusHtml .= '<div class="border-rounded padded-15 border-dotted">' . $sdmForm->sdmFormGetSubmittedFormValue($machineValue) . '</p></div>';
+            $wrapperStatusHtml .= '<p>wrapper content:';
+            $wrapperStatusHtml .= ($sdmForm->sdmFormGetSubmittedFormValue($machineValue) === '' ? ' This wrapper has no content.</p>' : '</p><div class="border-rounded padded-15 border-dotted">' . $sdmForm->sdmFormGetSubmittedFormValue($machineValue) . '</p></div>');
             $wrapperStatusHtml .= '</div>';
         }
 

--- a/core/apps/contentManager/handlers/contentManagerUpdateContentFormSubmission.php
+++ b/core/apps/contentManager/handlers/contentManagerUpdateContentFormSubmission.php
@@ -4,39 +4,57 @@
  * Update Content form submission handler for the Content Manager core app.
  */
 
-/** initialize form */
+/** Initialize form */
 $sdmForm = new SdmForm();
+
+/* Configure $options array */
 $options = array(
     'incpages' => array('contentManagerUpdateContentFormSubmission'),
 );
-if ($sdmForm->sdmFormGetSubmittedFormValue('page') !== 'contentManager') {
+
+/* Get submitted page name */
+$page = $sdmForm->sdmFormGetSubmittedFormValue('page');
+
+/* Make sure the user does not accidently create a page called contentManager. */
+if ($page !== 'contentManager') {
+    /* Initialize $output var */
     $output = '';
-    // form submitted successfully
+
+    /* Check if form was submitted successfully. */
     if ($sdmForm->sdmFormGetSubmittedFormValue('content_manager_form_submitted') === 'content_manager_form_submitted') {
-        $output .= '
-                    <!-- contentManager div -->
-                    <div id"contentManager">
-                        <p>Form has been submitted with the following values.
-                            <ul>
-                                <li>PAGE : <a href="' . $sdmassembler->sdmCoreGetRootDirectoryUrl() . '?page=' . $sdmForm->sdmFormGetSubmittedFormValue('page') . '">' . $sdmForm->sdmFormGetSubmittedFormValue('page') . '</a></li>';
-        // loop through and update wrappers
+        /* Initialize $wrapperStatusHtml. */
+        $wrapperStatusHtml = '';
+        /* Update each wrapper. */
         foreach ($sdmcms->sdmCmsDetermineAvailableWrappers() as $dispalyValue => $machineValue) {
-            $sdmcms->sdmCmsUpdateContent($sdmForm->sdmFormGetSubmittedFormValue('page'), $machineValue, nl2br($sdmForm->sdmFormGetSubmittedFormValue($machineValue)));
-            $output .= '<li>Wrapper : "' . $dispalyValue . '" (<i>' . $machineValue . '</i>)</li><li>Wrapper Content : <xmp>' . $sdmForm->sdmFormGetSubmittedFormValue($machineValue) . '</xmp></li>';
+            /* Update the wrapper in the DataObject. */
+            $sdmcms->sdmCmsUpdateContent($page, $machineValue, nl2br($sdmForm->sdmFormGetSubmittedFormValue($machineValue)));
+
+            /* Get html that will be used along with the rest of the app $output for each wrapper. */
+            $wrapperStatusHtml .= '<div class="border-rounded padded-15 highlight">';
+            $wrapperStatusHtml .= '<p>wrapper name: "' . $dispalyValue . '"';
+            $wrapperStatusHtml .= '<p>wrapper id: "' . $machineValue . '"</p>';
+            $wrapperStatusHtml .= '<p>wrapper content:</p>';
+            $wrapperStatusHtml .= '<div class="border-rounded padded-15 border-dotted">' . $sdmForm->sdmFormGetSubmittedFormValue($machineValue) . '</p></div>';
+            $wrapperStatusHtml .= '</div>';
         }
-        $output .= '
-                            </ul></p>
-                    </div>
-                    <!-- close contentManager div -->';
-    } // form submitted but error occured
+
+        /* App $output for successful update. */
+        $output .= '<!-- contentManager div -->';
+        $output .= '<div id="contentManager">';
+        $output .= '<p>Page updated successfully.</p>';
+        $output .= '<p>Go to <a href="' . $sdmassembler->sdmCoreGetRootDirectoryUrl() . '?page=' . $page . '">' . $page . '</a></p>';
+        $output .= '<p>Overview of content wrappers for this page:</p>';
+        $output .= $wrapperStatusHtml;
+        $output .= '</div><!-- close contentManager div -->';
+    }
     else {
-        $output .= '
-                <div id="contentManager">
-                    <p>And error occured and the form could not be submitted</p>
-                </div>
-                ';
+        /* App $output if form could not be submitted. */
+        $output .= '<div id="contentManager"><p>And error occurred and the form could not be submitted</p></div>';
     }
 } else {
-    $output = '<p>Page could not be created because pages cannot use the name "contentManager" for security reasons. You can however add a page for one of the content managers stages.</p>';
+    /* App $output if user tried to create a page called "contentManager". */
+    $output = '<p>Sorry, you cannot create a page with the name "contentManager" for security reasons.</p>';
 }
+
+/* Incorporate app $output. */
 $sdmassembler->sdmAssemblerIncorporateAppOutput($output, $options);

--- a/core/apps/contentManager/js/cm.js
+++ b/core/apps/contentManager/js/cm.js
@@ -1,0 +1,34 @@
+$(document).ready(function () {
+
+    /* Code for retrieveing $_GET values from post on stackoverflow.
+     @see http://stackoverflow.com/questions/439463/how-to-get-get-and-post-variables-with-jquery */
+    var $_GET = {};
+
+    document.location.search.replace(/\??(?:([^=]+)=([^&]*)&?)/g, function () {
+        function decode(s) {
+            return decodeURIComponent(s.split("+").join(" "));
+        }
+
+        $_GET[decode(arguments[1])] = decode(arguments[2]);
+    });
+
+    /* Determine requested page. */
+    var requestedPage = $_GET['page'];
+
+    /*Property to highlight */
+    var property = ".highlight";
+    if (requestedPage === 'contentManagerUpdateContentFormSubmission') {
+        /* Get initial color value */
+        var initialColor = $(".sdmResponsive").css("color");
+
+        /* mouseover effect */
+        $(property).on("mouseover", function () {
+            $(this).css("color", "red");
+        });
+
+        /* mouseout effect */
+        $(property).on("mouseout", function () {
+            $(this).css("color", initialColor);
+        });
+    }
+});

--- a/core/apps/contentManager/js/cm.js
+++ b/core/apps/contentManager/js/cm.js
@@ -23,7 +23,7 @@ $(document).ready(function () {
 
         /* mouseover effect */
         $(property).on("mouseover", function () {
-            $(this).css("color", "red");
+            $(this).css("color", "#00ff33");
         });
 
         /* mouseout effect */

--- a/core/config/defaultDataConfig.php
+++ b/core/config/defaultDataConfig.php
@@ -69,6 +69,7 @@ $config = array(
             'SdmDevMenu' => 'SdmDevMenu',
             'SdmErrorLog' => 'SdmErrorLog',
         ),
+        'requiredApps' => new stdClass(),
     ),
     /* Menus | @see "core/config/defaultMenuConfig.php" for default menu configuration */
     'menus' => $menus,

--- a/core/includes/SdmCms.php
+++ b/core/includes/SdmCms.php
@@ -295,10 +295,6 @@ class SdmCms extends SdmCore
                 if (!property_exists($enabledApps, $app)) {
                     $enabledApps->$app = trim($app);
                 }
-
-                // dev
-                $dev = ['App' => $app, 'State' => $state, 'Dependencies' => (empty($dependencies) ? 'No dependencies.' : $dependencies),'Apps To Be Enabled' => $enabledApps];
-                $this->sdmCoreSdmReadArray($dev);
                 break;
 
             case 'off': // Disable App //
@@ -306,10 +302,6 @@ class SdmCms extends SdmCore
                 if (property_exists($enabledApps, $app) && !property_exists($data->settings->requiredApps, $app)) {
                     unset($enabledApps->$app);
                 }
-
-                // dev
-                $dev = ['App' => $app, 'State' => $state, 'Dependencies' => (empty($dependencies) ? 'No dependencies.' : $dependencies),'Apps To Be Enabled' => $enabledApps];
-                $this->sdmCoreSdmReadArray($dev);
                 break;
 
             default: // Error, invalid $state
@@ -409,8 +401,6 @@ class SdmCms extends SdmCore
                 $enabledApps->$app = trim($app);
             }
         }
-        $dev = ['App' => $app, 'Dependencies' => $dependencies, 'Enabled Apps' => $enabledApps, 'DataObject->settings->requiredApps' => $dataObject->settings->requiredApps];
-        //$this->sdmCoreSdmReadArray($dev);
         return $dependencies;
     }
 }

--- a/core/includes/SdmCms.php
+++ b/core/includes/SdmCms.php
@@ -61,8 +61,8 @@ class SdmCms extends SdmCore
         /* Store the updates. */
         $update = file_put_contents($this->sdmCoreGetDataDirectoryPath() . '/data.json', $data, LOCK_EX);
 
-        /* Determine weather the update succeeded or failed.*/
-        $status = ($update < 0 || $update !== false ? true : false);
+        /* Determine weather the update succeeded or failed. */
+        $status = ($update < 0 && $update !== false ? true : false);
 
         /* Return true if update succeeded, or false if update failed. */
         return $status;

--- a/core/includes/SdmCms.php
+++ b/core/includes/SdmCms.php
@@ -18,12 +18,8 @@ class SdmCms extends SdmCore
      *
      * Warning: This method will overwrite content if it already exists.
      *
-     * @todo: It may be beneficial to split the update and add logic into 2 separate methods to
-     *        prevent accidental overwriting of pages that already exist. The other option
-     *        would be to create a parameter that dictates weather or not pages
-     *        that already exist should be overwritten. One final option would be to
-     *        create a method that called sdmCmsAddContent() that utilizes sdmCmsUpdateContent()
-     *        but performs a check to make sure existing pages are not overwritten.
+     * @todo: It may be beneficial to refactor the update logic to insure
+     *       pages that already exist do not get overwritten by mistake.
      *
      * @param string $page The name of the page this content belongs to.
      *

--- a/core/includes/SdmCms.php
+++ b/core/includes/SdmCms.php
@@ -352,6 +352,17 @@ class SdmCms extends SdmCore
      * @return array Array of apps the $app is dependent on.
      */
     final public function sdmCmsDetermineAppDependencies($app) {
-        return array('jQuery','jQueryUi');
+        /* Determine path to $app's directory. */
+       $appPath = (file_exists($this->sdmCoreGetCoreAppDirectoryPath() . '/' . $app) ? $this->sdmCoreGetCoreAppDirectoryPath() . '/' . $app : $this->sdmCoreGetUserAppDirectoryPath() . '/' . $app);
+
+        /* Build path to .cm file */
+        $cmFilePath = $appPath . '/' . $app . '.cm';
+
+        /* If it exists, load the $app.cm file. */
+        if(file_exists($cmFilePath)){
+            $definedDependencies = file_get_contents($cmFilePath);
+            $dependencies = explode(', ', $definedDependencies);
+        }
+        return (empty($dependencies) === true ? array() : $dependencies);
     }
 }

--- a/themes/sdmResponsive/css/wrappers.css
+++ b/themes/sdmResponsive/css/wrappers.css
@@ -8,8 +8,8 @@
 
 /* Wrappers */
 #side-menu, #main_content {
-    background: #000000;
-    opacity: .7;
+    background: #0C1923;
+    opacity: 0.69;
 }
 
 /* Tablet Styles */


### PR DESCRIPTION
Cleaned up code an code comments in various components. Cleaned up UI for contentManager core app components. Redefined various style definitions for sdmResponsive theme. Created .cm files which are used to communicate any dependencies an app may have to the SdmCms(). The SdmCms()'s sdmCmsSwitchAppState() method now registers requiredApps in the DataObject when appropriate. The contentManager administer apps form and form handler are now correctly handling apps, specifically, users are no longer allowed to disable apps registered as a requiredApp in the DataObject, and the administer apps form handler is now correctly displaying which apps were enabled, disabled, and which dependencies were enabled upon submission of administer apps form. @todo need to have sdmCmsSwitchAppState() un-register dependent apps registered under requiredApps when they are disabled. Additionally, if a required app has no dependencies it should be un-registered as a required app.;